### PR TITLE
Build core validation, conversion, storage, and API slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 .env
 .env.*
 PROJECT_LOG.md
+
+# Generated local outputs
+data/processed/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+__pycache__/
+.pytest_cache/
+*.pyc
+.env
+.env.*
+PROJECT_LOG.md

--- a/README.dev.md
+++ b/README.dev.md
@@ -35,3 +35,5 @@ The current implementation covers:
 - MariaDB dual-storage schema draft
 - service/API skeleton
 - benchmark tooling for JSON vs TOON payload size, token estimate, and conversion time
+- evaluator flow for pasted JSON demo responses
+- extracted-field search path for hybrid query demo

--- a/README.dev.md
+++ b/README.dev.md
@@ -38,11 +38,19 @@ PYTHONPATH=src python scripts/run_core_pipeline.py
 
 This exercises the first backend path end-to-end: validate JSON, convert valid records to TOON, extract SQL-friendly fields, and store accepted/rejected records with ingestion status.
 
+To include invalid sample payloads and verify rejected records remain auditable:
+
+```bash
+PYTHONPATH=src python scripts/run_core_pipeline.py --invalid-samples data/invalid_samples
+```
+
 To run the same core path against MariaDB after setting the environment variables above:
 
 ```bash
 PYTHONPATH=src python scripts/run_mariadb_pipeline.py
 ```
+
+It also accepts `--invalid-samples data/invalid_samples` for the same rejection/audit path against MariaDB.
 
 ## Run JSON vs TOON benchmark
 

--- a/README.dev.md
+++ b/README.dev.md
@@ -8,6 +8,12 @@ python3 -m venv .venv
 python -m pip install -r requirements.txt
 ```
 
+For live MariaDB connector work, install MariaDB Connector/C on the host first, then run:
+
+```bash
+python -m pip install -r requirements-mariadb.txt
+```
+
 ## Run tests
 
 ```bash

--- a/README.dev.md
+++ b/README.dev.md
@@ -20,6 +20,14 @@ python -m pip install -r requirements-mariadb.txt
 PYTHONPATH=src python -m pytest tests -q
 ```
 
+## Run core ingestion pipeline
+
+```bash
+PYTHONPATH=src python scripts/run_core_pipeline.py
+```
+
+This exercises the first backend path end-to-end: validate JSON, convert valid records to TOON, extract SQL-friendly fields, and store accepted/rejected records with ingestion status.
+
 ## Run JSON vs TOON benchmark
 
 ```bash

--- a/README.dev.md
+++ b/README.dev.md
@@ -1,0 +1,24 @@
+# Local development
+
+## Setup
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+## Run tests
+
+```bash
+PYTHONPATH=src python -m pytest tests -q
+```
+
+## Current backend slice
+
+The current implementation covers:
+- JSON validation
+- JSON to compact TOON-style conversion
+- SQL-friendly field extraction
+- MariaDB dual-storage schema draft
+- service/API skeleton

--- a/README.dev.md
+++ b/README.dev.md
@@ -37,3 +37,5 @@ The current implementation covers:
 - benchmark tooling for JSON vs TOON payload size, token estimate, and conversion time
 - evaluator flow for pasted JSON demo responses
 - extracted-field search path for hybrid query demo
+- `/demo` page for a simple interactive evaluator
+- `/query` endpoint for extracted-field filtering with TOON payload return

--- a/README.dev.md
+++ b/README.dev.md
@@ -52,6 +52,8 @@ PYTHONPATH=src python scripts/run_mariadb_pipeline.py
 
 It also accepts `--invalid-samples data/invalid_samples` for the same rejection/audit path against MariaDB.
 
+The test suite includes an optional live MariaDB integration test. It is skipped unless the `TOONFLOW_DB_*` environment variables are configured.
+
 ## Run JSON vs TOON benchmark
 
 ```bash

--- a/README.dev.md
+++ b/README.dev.md
@@ -14,6 +14,16 @@ For live MariaDB connector work, install MariaDB Connector/C on the host first, 
 python -m pip install -r requirements-mariadb.txt
 ```
 
+MariaDB connection settings are read from environment variables:
+
+```bash
+export TOONFLOW_DB_HOST=localhost
+export TOONFLOW_DB_PORT=3306
+export TOONFLOW_DB_USER=toonflow
+export TOONFLOW_DB_PASSWORD=...
+export TOONFLOW_DB_NAME=toonflow
+```
+
 ## Run tests
 
 ```bash
@@ -27,6 +37,12 @@ PYTHONPATH=src python scripts/run_core_pipeline.py
 ```
 
 This exercises the first backend path end-to-end: validate JSON, convert valid records to TOON, extract SQL-friendly fields, and store accepted/rejected records with ingestion status.
+
+To run the same core path against MariaDB after setting the environment variables above:
+
+```bash
+PYTHONPATH=src python scripts/run_mariadb_pipeline.py
+```
 
 ## Run JSON vs TOON benchmark
 

--- a/README.dev.md
+++ b/README.dev.md
@@ -20,6 +20,12 @@ python -m pip install -r requirements-mariadb.txt
 PYTHONPATH=src python -m pytest tests -q
 ```
 
+## Run JSON vs TOON benchmark
+
+```bash
+PYTHONPATH=src python scripts/run_benchmark.py
+```
+
 ## Current backend slice
 
 The current implementation covers:
@@ -28,3 +34,4 @@ The current implementation covers:
 - SQL-friendly field extraction
 - MariaDB dual-storage schema draft
 - service/API skeleton
+- benchmark tooling for JSON vs TOON payload size, token estimate, and conversion time

--- a/benchmarks/benchmark_protocol.md
+++ b/benchmarks/benchmark_protocol.md
@@ -9,10 +9,15 @@ Metrics captured:
 - UTF-8 payload bytes
 - estimated token count using a repeatable local `len(text) / 4` heuristic
 - byte and token savings percentage
+- estimated API cost using a configurable cost-per-million-token assumption
 - conversion time in milliseconds
+- derived conversion throughput in records per second
 
 The token metric is intentionally labelled as an estimate. A model-specific
 tokenizer can be swapped in later while keeping the same result schema.
+
+The cost metric is also an estimate. It is meant for relative comparison in the
+demo, not as a pricing claim.
 
 Run locally:
 

--- a/benchmarks/benchmark_protocol.md
+++ b/benchmarks/benchmark_protocol.md
@@ -1,0 +1,21 @@
+# JSON vs TOON benchmark protocol
+
+The benchmark compares the same source payload in two transport formats:
+
+1. canonical compact JSON
+2. TOONFlow's compact TOON-style field-path output
+
+Metrics captured:
+- UTF-8 payload bytes
+- estimated token count using a repeatable local `len(text) / 4` heuristic
+- byte and token savings percentage
+- conversion time in milliseconds
+
+The token metric is intentionally labelled as an estimate. A model-specific
+tokenizer can be swapped in later while keeping the same result schema.
+
+Run locally:
+
+```bash
+PYTHONPATH=src python scripts/run_benchmark.py
+```

--- a/benchmarks/latest_report.md
+++ b/benchmarks/latest_report.md
@@ -1,0 +1,17 @@
+# JSON vs TOON Benchmark Results
+
+| Payload | JSON bytes | TOON bytes | Byte savings | Token savings | Conversion ms |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| demo_invoice | 184 | 168 | 8.7% | 8.7% | 0.0854 |
+| demo_support_ticket | 359 | 324 | 9.75% | 10.0% | 0.0536 |
+
+## Totals
+
+- JSON bytes: 543
+- TOON bytes: 492
+- Byte savings: 9.39%
+- Estimated token savings: 9.56%
+- Estimated cost savings: $1.95e-06
+- Conversion throughput: 14388.49 records/sec
+
+Token and cost values are estimates for repeatable local comparison.

--- a/benchmarks/latest_results.json
+++ b/benchmarks/latest_results.json
@@ -10,30 +10,30 @@
       "toon_token_estimate": 42,
       "token_savings": 4,
       "token_savings_percent": 8.7,
-      "conversion_ms": 0.0855
+      "conversion_ms": 0.0953
     },
     {
       "payload_name": "demo_support_ticket",
       "json_bytes": 359,
-      "toon_bytes": 328,
-      "byte_savings": 31,
-      "byte_savings_percent": 8.64,
+      "toon_bytes": 324,
+      "byte_savings": 35,
+      "byte_savings_percent": 9.75,
       "json_token_estimate": 90,
-      "toon_token_estimate": 82,
-      "token_savings": 8,
-      "token_savings_percent": 8.89,
-      "conversion_ms": 0.0663
+      "toon_token_estimate": 81,
+      "token_savings": 9,
+      "token_savings_percent": 10.0,
+      "conversion_ms": 0.0598
     }
   ],
   "totals": {
     "json_bytes": 543,
-    "toon_bytes": 496,
+    "toon_bytes": 492,
     "json_token_estimate": 136,
-    "toon_token_estimate": 124,
-    "conversion_ms": 0.1518,
-    "byte_savings": 47,
-    "byte_savings_percent": 8.66,
-    "token_savings": 12,
-    "token_savings_percent": 8.82
+    "toon_token_estimate": 123,
+    "conversion_ms": 0.1551,
+    "byte_savings": 51,
+    "byte_savings_percent": 9.39,
+    "token_savings": 13,
+    "token_savings_percent": 9.56
   }
 }

--- a/benchmarks/latest_results.json
+++ b/benchmarks/latest_results.json
@@ -10,7 +10,11 @@
       "toon_token_estimate": 42,
       "token_savings": 4,
       "token_savings_percent": 8.7,
-      "conversion_ms": 0.0953
+      "json_estimated_cost_usd": 6.9e-06,
+      "toon_estimated_cost_usd": 6.3e-06,
+      "estimated_cost_savings_usd": 6e-07,
+      "records_per_second": 11709.33,
+      "conversion_ms": 0.0854
     },
     {
       "payload_name": "demo_support_ticket",
@@ -22,7 +26,11 @@
       "toon_token_estimate": 81,
       "token_savings": 9,
       "token_savings_percent": 10.0,
-      "conversion_ms": 0.0598
+      "json_estimated_cost_usd": 1.35e-05,
+      "toon_estimated_cost_usd": 1.215e-05,
+      "estimated_cost_savings_usd": 1.35e-06,
+      "records_per_second": 18667.87,
+      "conversion_ms": 0.0536
     }
   ],
   "totals": {
@@ -30,10 +38,14 @@
     "toon_bytes": 492,
     "json_token_estimate": 136,
     "toon_token_estimate": 123,
-    "conversion_ms": 0.1551,
+    "json_estimated_cost_usd": 2.04e-05,
+    "toon_estimated_cost_usd": 1.845e-05,
+    "conversion_ms": 0.139,
     "byte_savings": 51,
     "byte_savings_percent": 9.39,
     "token_savings": 13,
-    "token_savings_percent": 9.56
+    "token_savings_percent": 9.56,
+    "estimated_cost_savings_usd": 1.95e-06,
+    "records_per_second": 14388.49
   }
 }

--- a/benchmarks/latest_results.json
+++ b/benchmarks/latest_results.json
@@ -1,0 +1,39 @@
+{
+  "results": [
+    {
+      "payload_name": "demo_invoice",
+      "json_bytes": 184,
+      "toon_bytes": 168,
+      "byte_savings": 16,
+      "byte_savings_percent": 8.7,
+      "json_token_estimate": 46,
+      "toon_token_estimate": 42,
+      "token_savings": 4,
+      "token_savings_percent": 8.7,
+      "conversion_ms": 0.0855
+    },
+    {
+      "payload_name": "demo_support_ticket",
+      "json_bytes": 359,
+      "toon_bytes": 328,
+      "byte_savings": 31,
+      "byte_savings_percent": 8.64,
+      "json_token_estimate": 90,
+      "toon_token_estimate": 82,
+      "token_savings": 8,
+      "token_savings_percent": 8.89,
+      "conversion_ms": 0.0663
+    }
+  ],
+  "totals": {
+    "json_bytes": 543,
+    "toon_bytes": 496,
+    "json_token_estimate": 136,
+    "toon_token_estimate": 124,
+    "conversion_ms": 0.1518,
+    "byte_savings": 47,
+    "byte_savings_percent": 8.66,
+    "token_savings": 12,
+    "token_savings_percent": 8.82
+  }
+}

--- a/data/invalid_samples/bad_timestamp.json
+++ b/data/invalid_samples/bad_timestamp.json
@@ -1,0 +1,8 @@
+{
+  "id": "invalid-bad-timestamp",
+  "entity": "support_ticket",
+  "timestamp": "not-a-date",
+  "data": {
+    "priority": "high"
+  }
+}

--- a/data/invalid_samples/missing_data.json
+++ b/data/invalid_samples/missing_data.json
@@ -1,0 +1,5 @@
+{
+  "id": "invalid-missing-data",
+  "entity": "invoice",
+  "timestamp": "2026-04-24T10:00:00Z"
+}

--- a/data/samples/demo_invoice.json
+++ b/data/samples/demo_invoice.json
@@ -1,0 +1,14 @@
+{
+  "id": "demo-001",
+  "entity": "invoice",
+  "timestamp": "2026-04-23T12:00:00Z",
+  "data": {
+    "customer": {
+      "name": "Alice",
+      "tier": "gold"
+    },
+    "amount": 245.5,
+    "currency": "MYR",
+    "tags": ["priority", "renewal"]
+  }
+}

--- a/data/samples/demo_support_ticket.json
+++ b/data/samples/demo_support_ticket.json
@@ -1,0 +1,24 @@
+{
+  "id": "demo-002",
+  "entity": "support_ticket",
+  "timestamp": "2026-04-24T09:15:00Z",
+  "data": {
+    "customer": {
+      "name": "Farah",
+      "plan": "enterprise"
+    },
+    "priority": "high",
+    "category": "billing",
+    "messages": [
+      {
+        "sender": "customer",
+        "text": "Invoice total does not match the purchase order"
+      },
+      {
+        "sender": "agent",
+        "text": "Reviewing the billing line items and payment terms"
+      }
+    ],
+    "sla_hours": 4
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,23 @@ The architecture separates compact AI-oriented transport from normal SQL usabili
 - TOON is used for compact storage / prompt-oriented workflows
 - extracted fields are used for filtering, indexing, and reporting
 
+## Core ingestion contract
+The end-to-end backend path for the first implementation slice is:
+
+1. validate the JSON envelope (`entity`, `timestamp`, `data`, optional string `id`)
+2. reject malformed payloads with validation errors and ingestion status
+3. convert valid payloads into TOON
+4. flatten scalar fields into SQL-friendly paths such as `entity` or `data.amount`
+5. persist both accepted and rejected records so failures are auditable
+
+## MariaDB dual storage
+The storage design keeps two complementary shapes:
+
+- `toon_records`: full original JSON, TOON payload, extracted field JSON, metadata, status, errors, warnings
+- `toon_record_fields`: relational field rows with `field_path`, string/number/boolean typed values, and indexes for query paths
+
+This keeps the original payload and compact TOON representation intact while still allowing SQL-style lookup over extracted fields.
+
 ## Reliability focus
 The system should visibly support:
 - validation

--- a/docs/development-roadmap.md
+++ b/docs/development-roadmap.md
@@ -11,6 +11,8 @@
 - Define MariaDB schema
 - Store payloads, metadata, and extracted fields
 
+Current backend implementation covers this phase end-to-end: sample JSON payloads can be validated, converted to TOON, flattened into queryable fields, and stored through the in-memory or MariaDB repository paths. Invalid samples are stored as rejected records with validation errors so ingestion failures remain auditable.
+
 ## Phase 3 — API and retrieval flow (24–25 Apr)
 - Add ingest endpoint(s)
 - Add read/export endpoint(s)

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -22,3 +22,13 @@ Build a reliability-focused JSON-to-TOON ingestion gateway for MariaDB that prov
 
 ## Delivery principle
 Prefer proof over breadth: every major claim should be backed by either a working flow, a benchmark, or a clear demo step.
+
+## Current proof for core ingestion
+The first core backend path now has runnable evidence:
+
+```bash
+PYTHONPATH=src python -m pytest tests -q
+PYTHONPATH=src python scripts/run_core_pipeline.py --invalid-samples data/invalid_samples
+```
+
+This verifies JSON validation, rejection/audit behaviour, JSON-to-TOON conversion, extracted SQL-friendly fields, and dual-storage preparation for MariaDB.

--- a/requirements-mariadb.txt
+++ b/requirements-mariadb.txt
@@ -1,0 +1,2 @@
+# Requires MariaDB Connector/C (`mariadb_config`) to be installed on the host first.
+mariadb>=1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110
+mariadb>=1.1
+pytest>=8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fastapi>=0.110
-mariadb>=1.1
+httpx>=0.27
 pytest>=8.0

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from toonflow.benchmark import benchmark_payloads, load_json_payloads, write_benchmark_report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run JSON vs TOON benchmark over sample payloads.")
+    parser.add_argument("--samples", default=str(ROOT / "data" / "samples"), help="Directory of JSON samples")
+    parser.add_argument(
+        "--output",
+        default=str(ROOT / "benchmarks" / "latest_results.json"),
+        help="Path for JSON benchmark output",
+    )
+    args = parser.parse_args()
+
+    payloads = load_json_payloads(args.samples)
+    if not payloads:
+        raise SystemExit(f"No JSON sample payloads found in {args.samples}")
+
+    report = benchmark_payloads(payloads)
+    write_benchmark_report(report, args.output)
+    totals = report["totals"]
+    print(f"Benchmarked {len(payloads)} payload(s)")
+    print(f"JSON bytes: {totals['json_bytes']}")
+    print(f"TOON bytes: {totals['toon_bytes']}")
+    print(f"Byte savings: {totals['byte_savings_percent']}%")
+    print(f"Estimated token savings: {totals['token_savings_percent']}%")
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -10,7 +10,7 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from toonflow.benchmark import benchmark_payloads, load_json_payloads, write_benchmark_report
+from toonflow.benchmark import benchmark_payloads, load_json_payloads, write_benchmark_report, write_markdown_report
 
 
 def main() -> int:
@@ -21,6 +21,11 @@ def main() -> int:
         default=str(ROOT / "benchmarks" / "latest_results.json"),
         help="Path for JSON benchmark output",
     )
+    parser.add_argument(
+        "--markdown-output",
+        default=str(ROOT / "benchmarks" / "latest_report.md"),
+        help="Path for Markdown benchmark summary",
+    )
     args = parser.parse_args()
 
     payloads = load_json_payloads(args.samples)
@@ -29,13 +34,17 @@ def main() -> int:
 
     report = benchmark_payloads(payloads)
     write_benchmark_report(report, args.output)
+    write_markdown_report(report, args.markdown_output)
     totals = report["totals"]
     print(f"Benchmarked {len(payloads)} payload(s)")
     print(f"JSON bytes: {totals['json_bytes']}")
     print(f"TOON bytes: {totals['toon_bytes']}")
     print(f"Byte savings: {totals['byte_savings_percent']}%")
     print(f"Estimated token savings: {totals['token_savings_percent']}%")
+    print(f"Estimated cost savings: ${totals['estimated_cost_savings_usd']}")
+    print(f"Conversion throughput: {totals['records_per_second']} records/sec")
     print(f"Wrote {args.output}")
+    print(f"Wrote {args.markdown_output}")
     return 0
 
 

--- a/scripts/run_core_pipeline.py
+++ b/scripts/run_core_pipeline.py
@@ -18,13 +18,21 @@ from toonflow.service import batch_ingest_and_store_payloads
 def load_payloads(samples_dir: Path) -> list[dict]:
     payloads = []
     for path in sorted(samples_dir.glob("*.json")):
-        payloads.append(json.loads(path.read_text(encoding="utf-8")))
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict) and "id" not in payload:
+            payload["id"] = path.stem
+        payloads.append(payload)
     return payloads
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run the core validate -> convert -> dual-store pipeline.")
     parser.add_argument("--samples", default=str(ROOT / "data" / "samples"), help="Directory containing sample JSON files")
+    parser.add_argument(
+        "--invalid-samples",
+        default=None,
+        help="Optional directory of invalid JSON payloads to include for rejection/audit checks",
+    )
     parser.add_argument(
         "--output",
         default=str(ROOT / "data" / "processed" / "core_pipeline_results.json"),
@@ -34,6 +42,8 @@ def main() -> int:
 
     samples_dir = Path(args.samples)
     payloads = load_payloads(samples_dir)
+    if args.invalid_samples:
+        payloads.extend(load_payloads(Path(args.invalid_samples)))
     if not payloads:
         raise SystemExit(f"No JSON payloads found in {samples_dir}")
 

--- a/scripts/run_core_pipeline.py
+++ b/scripts/run_core_pipeline.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from toonflow.repository import InMemoryRecordStore
+from toonflow.service import batch_ingest_and_store_payloads
+
+
+def load_payloads(samples_dir: Path) -> list[dict]:
+    payloads = []
+    for path in sorted(samples_dir.glob("*.json")):
+        payloads.append(json.loads(path.read_text(encoding="utf-8")))
+    return payloads
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the core validate -> convert -> dual-store pipeline.")
+    parser.add_argument("--samples", default=str(ROOT / "data" / "samples"), help="Directory containing sample JSON files")
+    parser.add_argument(
+        "--output",
+        default=str(ROOT / "data" / "processed" / "core_pipeline_results.json"),
+        help="Output file for the pipeline summary",
+    )
+    args = parser.parse_args()
+
+    samples_dir = Path(args.samples)
+    payloads = load_payloads(samples_dir)
+    if not payloads:
+        raise SystemExit(f"No JSON payloads found in {samples_dir}")
+
+    store = InMemoryRecordStore()
+    result = batch_ingest_and_store_payloads(payloads, store, source="core-pipeline")
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    print(f"Processed {result['total']} payload(s)")
+    print(f"Accepted: {result['accepted']}")
+    print(f"Rejected: {result['rejected']}")
+    print(f"Stored records: {result['stored']}")
+    print(f"Wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_mariadb_pipeline.py
+++ b/scripts/run_mariadb_pipeline.py
@@ -17,16 +17,29 @@ from toonflow.service import batch_ingest_and_store_payloads
 
 
 def load_payloads(samples_dir: Path) -> list[dict]:
-    return [json.loads(path.read_text(encoding="utf-8")) for path in sorted(samples_dir.glob("*.json"))]
+    payloads = []
+    for path in sorted(samples_dir.glob("*.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict) and "id" not in payload:
+            payload["id"] = path.stem
+        payloads.append(payload)
+    return payloads
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run core ingestion pipeline against MariaDB.")
     parser.add_argument("--samples", default=str(ROOT / "data" / "samples"), help="Directory containing sample JSON files")
+    parser.add_argument(
+        "--invalid-samples",
+        default=None,
+        help="Optional directory of invalid JSON payloads to include for rejection/audit checks",
+    )
     parser.add_argument("--skip-schema", action="store_true", help="Do not run CREATE TABLE IF NOT EXISTS first")
     args = parser.parse_args()
 
     payloads = load_payloads(Path(args.samples))
+    if args.invalid_samples:
+        payloads.extend(load_payloads(Path(args.invalid_samples)))
     if not payloads:
         raise SystemExit(f"No JSON payloads found in {args.samples}")
 

--- a/scripts/run_mariadb_pipeline.py
+++ b/scripts/run_mariadb_pipeline.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from toonflow.db import connect_mariadb, load_mariadb_config
+from toonflow.mariadb_repository import MariaDBRecordRepository
+from toonflow.service import batch_ingest_and_store_payloads
+
+
+def load_payloads(samples_dir: Path) -> list[dict]:
+    return [json.loads(path.read_text(encoding="utf-8")) for path in sorted(samples_dir.glob("*.json"))]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run core ingestion pipeline against MariaDB.")
+    parser.add_argument("--samples", default=str(ROOT / "data" / "samples"), help="Directory containing sample JSON files")
+    parser.add_argument("--skip-schema", action="store_true", help="Do not run CREATE TABLE IF NOT EXISTS first")
+    args = parser.parse_args()
+
+    payloads = load_payloads(Path(args.samples))
+    if not payloads:
+        raise SystemExit(f"No JSON payloads found in {args.samples}")
+
+    config = load_mariadb_config()
+    connection = connect_mariadb(config)
+    repo = MariaDBRecordRepository(connection)
+    if not args.skip_schema:
+        repo.create_schema()
+
+    result = batch_ingest_and_store_payloads(payloads, repo, source="mariadb-pipeline")
+    print(f"Connected to MariaDB: {config.redacted()}")
+    print(f"Processed {result['total']} payload(s)")
+    print(f"Accepted: {result['accepted']}")
+    print(f"Rejected: {result['rejected']}")
+    print(f"Stored records: {result['stored']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/toonflow/__init__.py
+++ b/src/toonflow/__init__.py
@@ -1,0 +1,17 @@
+"""Core package for TOONFlow."""
+
+from .converter import flatten_query_fields, json_to_toon
+from .models import IngestRecord, IngestRequest, ValidationResult
+from .service import build_ingest_record, ingest_payload
+from .validator import validate_payload
+
+__all__ = [
+    "IngestRecord",
+    "IngestRequest",
+    "ValidationResult",
+    "build_ingest_record",
+    "flatten_query_fields",
+    "ingest_payload",
+    "json_to_toon",
+    "validate_payload",
+]

--- a/src/toonflow/__init__.py
+++ b/src/toonflow/__init__.py
@@ -2,15 +2,17 @@
 
 from .converter import flatten_query_fields, json_to_toon
 from .models import IngestRecord, IngestRequest, ValidationResult
-from .service import build_ingest_record, ingest_payload
+from .service import batch_ingest_and_store_payloads, build_ingest_record, ingest_and_store_payload, ingest_payload
 from .validator import validate_payload
 
 __all__ = [
     "IngestRecord",
     "IngestRequest",
     "ValidationResult",
+    "batch_ingest_and_store_payloads",
     "build_ingest_record",
     "flatten_query_fields",
+    "ingest_and_store_payload",
     "ingest_payload",
     "json_to_toon",
     "validate_payload",

--- a/src/toonflow/api.py
+++ b/src/toonflow/api.py
@@ -8,7 +8,19 @@ except ImportError:  # keep import-safe for local module testing
     FastAPI = None
     HTTPException = Exception
 
-from .service import ingest_payload
+from .repository import InMemoryRecordStore
+from .service import (
+    batch_ingest_payloads,
+    build_batch_records,
+    build_ingest_record,
+    convert_only,
+    export_record,
+    summarize_record,
+    validate_only,
+)
+
+
+store = InMemoryRecordStore()
 
 app = FastAPI(title='TOONFlow API') if FastAPI else None
 
@@ -17,9 +29,54 @@ if app is not None:
     def health() -> dict[str, str]:
         return {'status': 'ok'}
 
-    @app.post('/ingest')
-    def ingest_endpoint(payload: dict[str, Any]) -> dict[str, Any]:
-        result = ingest_payload(payload, source='api')
+    @app.post('/validate')
+    def validate_endpoint(payload: dict[str, Any]) -> dict[str, Any]:
+        return validate_only(payload)
+
+    @app.post('/convert')
+    def convert_endpoint(payload: dict[str, Any]) -> dict[str, Any]:
+        result = convert_only(payload)
         if result['status'] == 'rejected':
             raise HTTPException(status_code=400, detail=result)
         return result
+
+    @app.post('/ingest')
+    def ingest_endpoint(payload: dict[str, Any]) -> dict[str, Any]:
+        record = build_ingest_record_from_api(payload)
+        result = summarize_record(record)
+        if record.status == 'rejected':
+            raise HTTPException(status_code=400, detail=result)
+        store.save(record)
+        return result
+
+    @app.post('/batch/ingest')
+    def batch_ingest_endpoint(payloads: list[dict[str, Any]]) -> dict[str, Any]:
+        result = batch_ingest_payloads(payloads, source='api-batch')
+        for record in build_batch_records(payloads, source='api-batch'):
+            if record.status == 'validated':
+                store.save(record)
+        return result
+
+    @app.get('/records')
+    def list_records_endpoint() -> list[dict[str, Any]]:
+        return [summarize_record(record) for record in store.list()]
+
+    @app.get('/records/{payload_id}')
+    def read_record_endpoint(payload_id: str) -> dict[str, Any]:
+        record = store.get(payload_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail={'message': 'Record not found'})
+        return summarize_record(record)
+
+    @app.get('/records/{payload_id}/export')
+    def export_record_endpoint(payload_id: str) -> dict[str, Any]:
+        record = store.get(payload_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail={'message': 'Record not found'})
+        return export_record(record)
+
+
+def build_ingest_record_from_api(payload: dict[str, Any]):
+    from .models import IngestRequest
+
+    return build_ingest_record(IngestRequest(source='api', payload=payload))

--- a/src/toonflow/api.py
+++ b/src/toonflow/api.py
@@ -9,6 +9,7 @@ except ImportError:  # keep import-safe for local module testing
     HTTPException = Exception
 
 from .repository import InMemoryRecordStore
+from .evaluator import evaluate_payload
 from .service import (
     batch_ingest_payloads,
     build_batch_records,
@@ -40,6 +41,13 @@ if app is not None:
             raise HTTPException(status_code=400, detail=result)
         return result
 
+    @app.post('/evaluate')
+    def evaluate_endpoint(payload: dict[str, Any]) -> dict[str, Any]:
+        result = evaluate_payload(payload, payload_name=str(payload.get('id', 'payload')))
+        if result['status'] == 'rejected':
+            raise HTTPException(status_code=400, detail=result)
+        return result
+
     @app.post('/ingest')
     def ingest_endpoint(payload: dict[str, Any]) -> dict[str, Any]:
         record = build_ingest_record_from_api(payload)
@@ -60,6 +68,10 @@ if app is not None:
     @app.get('/records')
     def list_records_endpoint() -> list[dict[str, Any]]:
         return [summarize_record(record) for record in store.list()]
+
+    @app.get('/records/search')
+    def search_records_endpoint(field: str, value: str) -> list[dict[str, Any]]:
+        return [summarize_record(record) for record in store.find_by_field(field, value)]
 
     @app.get('/records/{payload_id}')
     def read_record_endpoint(payload_id: str) -> dict[str, Any]:

--- a/src/toonflow/api.py
+++ b/src/toonflow/api.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from fastapi import FastAPI, HTTPException
+except ImportError:  # keep import-safe for local module testing
+    FastAPI = None
+    HTTPException = Exception
+
+from .service import ingest_payload
+
+app = FastAPI(title='TOONFlow API') if FastAPI else None
+
+if app is not None:
+    @app.get('/health')
+    def health() -> dict[str, str]:
+        return {'status': 'ok'}
+
+    @app.post('/ingest')
+    def ingest_endpoint(payload: dict[str, Any]) -> dict[str, Any]:
+        result = ingest_payload(payload, source='api')
+        if result['status'] == 'rejected':
+            raise HTTPException(status_code=400, detail=result)
+        return result

--- a/src/toonflow/api.py
+++ b/src/toonflow/api.py
@@ -4,12 +4,15 @@ from typing import Any
 
 try:
     from fastapi import FastAPI, HTTPException
+    from fastapi.responses import HTMLResponse
 except ImportError:  # keep import-safe for local module testing
     FastAPI = None
     HTTPException = Exception
+    HTMLResponse = None
 
-from .repository import InMemoryRecordStore
 from .evaluator import evaluate_payload
+from .query import hybrid_query_response
+from .repository import InMemoryRecordStore
 from .service import (
     batch_ingest_payloads,
     build_batch_records,
@@ -25,10 +28,52 @@ store = InMemoryRecordStore()
 
 app = FastAPI(title='TOONFlow API') if FastAPI else None
 
+
+DEMO_HTML = """
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>TOONFlow Demo</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 1100px; margin: 2rem auto; padding: 0 1rem; }
+    textarea { width: 100%; min-height: 260px; font-family: ui-monospace, monospace; }
+    button { margin: 0.5rem 0.5rem 0.5rem 0; padding: 0.6rem 1rem; }
+    pre { background: #111827; color: #e5e7eb; padding: 1rem; overflow: auto; }
+  </style>
+</head>
+<body>
+  <h1>TOONFlow evaluator</h1>
+  <p>Paste JSON, validate it, convert it to TOON, and inspect extracted MariaDB query fields.</p>
+  <textarea id="payload">{"id":"demo-ui-001","entity":"invoice","timestamp":"2026-04-24T10:00:00Z","data":{"customer":{"name":"Alice"},"amount":245.5}}</textarea>
+  <br />
+  <button onclick="send('/evaluate')">Evaluate</button>
+  <button onclick="send('/ingest')">Ingest</button>
+  <button onclick="queryDemo()">Query entity=invoice</button>
+  <pre id="output">Ready.</pre>
+  <script>
+    async function send(path) {
+      const payload = JSON.parse(document.getElementById('payload').value);
+      const response = await fetch(path, { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload) });
+      document.getElementById('output').textContent = JSON.stringify(await response.json(), null, 2);
+    }
+    async function queryDemo() {
+      const response = await fetch('/query', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({field: 'entity', operator: 'eq', value: 'invoice'}) });
+      document.getElementById('output').textContent = JSON.stringify(await response.json(), null, 2);
+    }
+  </script>
+</body>
+</html>
+""".strip()
+
 if app is not None:
     @app.get('/health')
     def health() -> dict[str, str]:
         return {'status': 'ok'}
+
+    @app.get('/demo', response_class=HTMLResponse)
+    def demo_page() -> str:
+        return DEMO_HTML
 
     @app.post('/validate')
     def validate_endpoint(payload: dict[str, Any]) -> dict[str, Any]:
@@ -64,6 +109,18 @@ if app is not None:
             if record.status == 'validated':
                 store.save(record)
         return result
+
+    @app.post('/query')
+    def query_endpoint(query: dict[str, Any]) -> dict[str, Any]:
+        field = str(query.get('field', ''))
+        value = query.get('value')
+        operator = str(query.get('operator', 'eq'))
+        if not field:
+            raise HTTPException(status_code=400, detail={'message': 'field is required'})
+        try:
+            return hybrid_query_response(store.list(), field, value, operator)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail={'message': str(exc)}) from exc
 
     @app.get('/records')
     def list_records_endpoint() -> list[dict[str, Any]]:

--- a/src/toonflow/benchmark.py
+++ b/src/toonflow/benchmark.py
@@ -9,6 +9,9 @@ from typing import Any
 from .converter import json_to_toon
 
 
+DEFAULT_COST_PER_MILLION_TOKENS_USD = 0.15
+
+
 @dataclass(slots=True)
 class BenchmarkResult:
     payload_name: str
@@ -20,6 +23,10 @@ class BenchmarkResult:
     toon_token_estimate: int
     token_savings: int
     token_savings_percent: float
+    json_estimated_cost_usd: float
+    toon_estimated_cost_usd: float
+    estimated_cost_savings_usd: float
+    records_per_second: float
     conversion_ms: float
 
     def to_dict(self) -> dict[str, Any]:
@@ -48,6 +55,10 @@ def percentage_savings(original: int, compact: int) -> float:
     return round(((original - compact) / original) * 100, 2)
 
 
+def estimate_cost_usd(tokens: int, cost_per_million_tokens: float = DEFAULT_COST_PER_MILLION_TOKENS_USD) -> float:
+    return round((tokens / 1_000_000) * cost_per_million_tokens, 8)
+
+
 def benchmark_payload(payload: dict[str, Any], payload_name: str = "payload") -> BenchmarkResult:
     start = perf_counter()
     toon_payload = json_to_toon(payload)
@@ -58,6 +69,9 @@ def benchmark_payload(payload: dict[str, Any], payload_name: str = "payload") ->
     toon_bytes = len(toon_payload.encode("utf-8"))
     json_tokens = estimate_tokens(json_payload)
     toon_tokens = estimate_tokens(toon_payload)
+    json_cost = estimate_cost_usd(json_tokens)
+    toon_cost = estimate_cost_usd(toon_tokens)
+    records_per_second = round(1000 / conversion_ms, 2) if conversion_ms > 0 else 0.0
 
     return BenchmarkResult(
         payload_name=payload_name,
@@ -69,6 +83,10 @@ def benchmark_payload(payload: dict[str, Any], payload_name: str = "payload") ->
         toon_token_estimate=toon_tokens,
         token_savings=json_tokens - toon_tokens,
         token_savings_percent=percentage_savings(json_tokens, toon_tokens),
+        json_estimated_cost_usd=json_cost,
+        toon_estimated_cost_usd=toon_cost,
+        estimated_cost_savings_usd=round(json_cost - toon_cost, 8),
+        records_per_second=records_per_second,
         conversion_ms=round(conversion_ms, 4),
     )
 
@@ -80,6 +98,8 @@ def benchmark_payloads(payloads: dict[str, dict[str, Any]]) -> dict[str, Any]:
         "toon_bytes": sum(item.toon_bytes for item in results),
         "json_token_estimate": sum(item.json_token_estimate for item in results),
         "toon_token_estimate": sum(item.toon_token_estimate for item in results),
+        "json_estimated_cost_usd": round(sum(item.json_estimated_cost_usd for item in results), 8),
+        "toon_estimated_cost_usd": round(sum(item.toon_estimated_cost_usd for item in results), 8),
         "conversion_ms": round(sum(item.conversion_ms for item in results), 4),
     }
     totals["byte_savings"] = totals["json_bytes"] - totals["toon_bytes"]
@@ -88,6 +108,10 @@ def benchmark_payloads(payloads: dict[str, dict[str, Any]]) -> dict[str, Any]:
     totals["token_savings_percent"] = percentage_savings(
         totals["json_token_estimate"], totals["toon_token_estimate"]
     )
+    totals["estimated_cost_savings_usd"] = round(
+        totals["json_estimated_cost_usd"] - totals["toon_estimated_cost_usd"], 8
+    )
+    totals["records_per_second"] = round((len(results) * 1000) / totals["conversion_ms"], 2) if totals["conversion_ms"] else 0.0
     return {
         "results": [item.to_dict() for item in results],
         "totals": totals,
@@ -107,3 +131,36 @@ def write_benchmark_report(report: dict[str, Any], output_path: str | Path) -> N
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_markdown_report(report: dict[str, Any], output_path: str | Path) -> None:
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    totals = report["totals"]
+    lines = [
+        "# JSON vs TOON Benchmark Results",
+        "",
+        "| Payload | JSON bytes | TOON bytes | Byte savings | Token savings | Conversion ms |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for item in report["results"]:
+        lines.append(
+            f"| {item['payload_name']} | {item['json_bytes']} | {item['toon_bytes']} | "
+            f"{item['byte_savings_percent']}% | {item['token_savings_percent']}% | {item['conversion_ms']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Totals",
+            "",
+            f"- JSON bytes: {totals['json_bytes']}",
+            f"- TOON bytes: {totals['toon_bytes']}",
+            f"- Byte savings: {totals['byte_savings_percent']}%",
+            f"- Estimated token savings: {totals['token_savings_percent']}%",
+            f"- Estimated cost savings: ${totals['estimated_cost_savings_usd']}",
+            f"- Conversion throughput: {totals['records_per_second']} records/sec",
+            "",
+            "Token and cost values are estimates for repeatable local comparison.",
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/src/toonflow/benchmark.py
+++ b/src/toonflow/benchmark.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from .converter import json_to_toon
+
+
+@dataclass(slots=True)
+class BenchmarkResult:
+    payload_name: str
+    json_bytes: int
+    toon_bytes: int
+    byte_savings: int
+    byte_savings_percent: float
+    json_token_estimate: int
+    toon_token_estimate: int
+    token_savings: int
+    token_savings_percent: float
+    conversion_ms: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def estimate_tokens(text: str) -> int:
+    """Approximate token count for repeatable local benchmarking.
+
+    The hackathon demo should label this as an estimate. Exact tokenizer-based
+    counts can be swapped in later without changing the benchmark output shape.
+    """
+
+    if not text:
+        return 0
+    return max(1, round(len(text) / 4))
+
+
+def percentage_savings(original: int, compact: int) -> float:
+    if original <= 0:
+        return 0.0
+    return round(((original - compact) / original) * 100, 2)
+
+
+def benchmark_payload(payload: dict[str, Any], payload_name: str = "payload") -> BenchmarkResult:
+    start = perf_counter()
+    toon_payload = json_to_toon(payload)
+    conversion_ms = (perf_counter() - start) * 1000
+
+    json_payload = canonical_json(payload)
+    json_bytes = len(json_payload.encode("utf-8"))
+    toon_bytes = len(toon_payload.encode("utf-8"))
+    json_tokens = estimate_tokens(json_payload)
+    toon_tokens = estimate_tokens(toon_payload)
+
+    return BenchmarkResult(
+        payload_name=payload_name,
+        json_bytes=json_bytes,
+        toon_bytes=toon_bytes,
+        byte_savings=json_bytes - toon_bytes,
+        byte_savings_percent=percentage_savings(json_bytes, toon_bytes),
+        json_token_estimate=json_tokens,
+        toon_token_estimate=toon_tokens,
+        token_savings=json_tokens - toon_tokens,
+        token_savings_percent=percentage_savings(json_tokens, toon_tokens),
+        conversion_ms=round(conversion_ms, 4),
+    )
+
+
+def benchmark_payloads(payloads: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    results = [benchmark_payload(payload, name) for name, payload in payloads.items()]
+    totals = {
+        "json_bytes": sum(item.json_bytes for item in results),
+        "toon_bytes": sum(item.toon_bytes for item in results),
+        "json_token_estimate": sum(item.json_token_estimate for item in results),
+        "toon_token_estimate": sum(item.toon_token_estimate for item in results),
+        "conversion_ms": round(sum(item.conversion_ms for item in results), 4),
+    }
+    totals["byte_savings"] = totals["json_bytes"] - totals["toon_bytes"]
+    totals["byte_savings_percent"] = percentage_savings(totals["json_bytes"], totals["toon_bytes"])
+    totals["token_savings"] = totals["json_token_estimate"] - totals["toon_token_estimate"]
+    totals["token_savings_percent"] = percentage_savings(
+        totals["json_token_estimate"], totals["toon_token_estimate"]
+    )
+    return {
+        "results": [item.to_dict() for item in results],
+        "totals": totals,
+    }
+
+
+def load_json_payloads(directory: str | Path) -> dict[str, dict[str, Any]]:
+    base = Path(directory)
+    payloads: dict[str, dict[str, Any]] = {}
+    for path in sorted(base.glob("*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            payloads[path.stem] = json.load(handle)
+    return payloads
+
+
+def write_benchmark_report(report: dict[str, Any], output_path: str | Path) -> None:
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")

--- a/src/toonflow/converter.py
+++ b/src/toonflow/converter.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping
 from typing import Any
+
+
+UNQUOTED_STRING = re.compile(r"^[A-Za-z0-9_./:@+-]+$")
 
 
 def _format_scalar(value: Any) -> str:
@@ -12,41 +16,76 @@ def _format_scalar(value: Any) -> str:
         return "true" if value else "false"
     if isinstance(value, (int, float)):
         return str(value)
-    return json.dumps(str(value), ensure_ascii=False)
+    text = str(value)
+    if text and UNQUOTED_STRING.fullmatch(text):
+        return text
+    return json.dumps(text, ensure_ascii=False)
 
 
-def _flatten_lines(obj: Any, prefix: str = "") -> list[str]:
+def _inline_list(values: list[Any]) -> str:
+    return "[" + ",".join(_format_scalar(value) for value in values) + "]"
+
+
+def _is_scalar(value: Any) -> bool:
+    return not isinstance(value, (Mapping, list))
+
+
+def _table_columns(values: list[Any]) -> list[str] | None:
+    if not values or not all(isinstance(item, Mapping) for item in values):
+        return None
+
+    first_keys = list(values[0].keys())
+    if not first_keys:
+        return None
+
+    for item in values:
+        if list(item.keys()) != first_keys:
+            return None
+        if not all(_is_scalar(value) for value in item.values()):
+            return None
+    return [str(key) for key in first_keys]
+
+
+def _toon_lines(obj: Any, indent: int = 0) -> list[str]:
+    pad = " " * indent
     lines: list[str] = []
 
-    if isinstance(obj, Mapping):
-        for key, value in obj.items():
-            field = f"{prefix}.{key}" if prefix else str(key)
-            if isinstance(value, Mapping):
-                lines.extend(_flatten_lines(value, field))
-            elif isinstance(value, list):
-                lines.append(f"{field}[]: {len(value)}")
-                for index, item in enumerate(value):
-                    item_field = f"{field}[{index}]"
-                    if isinstance(item, Mapping):
-                        lines.extend(_flatten_lines(item, item_field))
-                    else:
-                        lines.append(f"{item_field}: {_format_scalar(item)}")
+    if not isinstance(obj, Mapping):
+        return [f"{pad}value: {_format_scalar(obj)}"]
+
+    for key, value in obj.items():
+        if isinstance(value, Mapping):
+            lines.append(f"{pad}{key}:")
+            lines.extend(_toon_lines(value, indent + 2))
+        elif isinstance(value, list):
+            if all(not isinstance(item, (Mapping, list)) for item in value):
+                lines.append(f"{pad}{key}: {_inline_list(value)}")
+            elif columns := _table_columns(value):
+                lines.append(f"{pad}{key}[{len(value)}]{{{','.join(columns)}}}:")
+                for item in value:
+                    row = ",".join(_format_scalar(item[column]) for column in columns)
+                    lines.append(f"{' ' * (indent + 2)}{row}")
             else:
-                lines.append(f"{field}: {_format_scalar(value)}")
-    else:
-        lines.append(f"value: {_format_scalar(obj)}")
+                lines.append(f"{pad}{key}[{len(value)}]:")
+                for item in value:
+                    if isinstance(item, Mapping):
+                        child_lines = _toon_lines(item, indent + 4)
+                        if child_lines:
+                            first = child_lines[0].lstrip()
+                            lines.append(f"{' ' * (indent + 2)}- {first}")
+                            lines.extend(child_lines[1:])
+                    else:
+                        lines.append(f"{' ' * (indent + 2)}- {_format_scalar(item)}")
+        else:
+            lines.append(f"{pad}{key}: {_format_scalar(value)}")
 
     return lines
 
 
 def json_to_toon(payload: Mapping[str, Any]) -> str:
-    """Return a compact field-path representation suitable for prompt transport.
+    """Return a compact TOON-style representation suitable for prompt transport."""
 
-    This first implementation uses explicit flattened paths so the output remains
-    easy to inspect, benchmark, and map back to SQL-friendly extracted fields.
-    """
-
-    return "\n".join(_flatten_lines(payload))
+    return "\n".join(_toon_lines(payload))
 
 
 def flatten_query_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -75,4 +114,3 @@ def flatten_query_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
 
     visit(payload)
     return fields
-

--- a/src/toonflow/converter.py
+++ b/src/toonflow/converter.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
 import json
-import re
 from collections.abc import Mapping
 from typing import Any
-
-
-UNQUOTED_STRING = re.compile(r"^[A-Za-z0-9_./:@+-]+$")
 
 
 def _format_scalar(value: Any) -> str:
@@ -17,7 +13,7 @@ def _format_scalar(value: Any) -> str:
     if isinstance(value, (int, float)):
         return str(value)
     text = str(value)
-    if text and UNQUOTED_STRING.fullmatch(text):
+    if text and "\n" not in text and not any(char in text for char in ",[]{}"):
         return text
     return json.dumps(text, ensure_ascii=False)
 

--- a/src/toonflow/converter.py
+++ b/src/toonflow/converter.py
@@ -12,6 +12,8 @@ def _format_scalar(value: Any) -> str:
         return "true" if value else "false"
     if isinstance(value, (int, float)):
         return str(value)
+    if isinstance(value, (Mapping, list)):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
     text = str(value)
     if text and "\n" not in text and not any(char in text for char in ",[]{}"):
         return text
@@ -93,26 +95,25 @@ def flatten_query_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
 
     fields: dict[str, Any] = {}
 
+    def visit_value(value: Any, field: str) -> None:
+        if isinstance(value, Mapping):
+            visit(value, field)
+        elif isinstance(value, list):
+            fields[f"{field}.__len__"] = len(value)
+            if value and all(not isinstance(item, (Mapping, list)) for item in value):
+                fields[field] = ",".join(str(item) for item in value)
+            for index, item in enumerate(value):
+                visit_value(item, f"{field}[{index}]")
+        else:
+            fields[field] = value
+
     def visit(obj: Any, prefix: str = "") -> None:
         if not isinstance(obj, Mapping):
             return
 
         for key, value in obj.items():
             field = f"{prefix}.{key}" if prefix else str(key)
-            if isinstance(value, Mapping):
-                visit(value, field)
-            elif isinstance(value, list):
-                fields[f"{field}.__len__"] = len(value)
-                if value and all(not isinstance(item, (Mapping, list)) for item in value):
-                    fields[field] = ",".join(str(item) for item in value)
-                else:
-                    for index, item in enumerate(value):
-                        if isinstance(item, Mapping):
-                            visit(item, f"{field}[{index}]")
-                        elif not isinstance(item, list):
-                            fields[f"{field}[{index}]"] = item
-            else:
-                fields[field] = value
+            visit_value(value, field)
 
     visit(payload)
     return fields

--- a/src/toonflow/converter.py
+++ b/src/toonflow/converter.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+def _format_scalar(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _flatten_lines(obj: Any, prefix: str = "") -> list[str]:
+    lines: list[str] = []
+
+    if isinstance(obj, Mapping):
+        for key, value in obj.items():
+            field = f"{prefix}.{key}" if prefix else str(key)
+            if isinstance(value, Mapping):
+                lines.extend(_flatten_lines(value, field))
+            elif isinstance(value, list):
+                lines.append(f"{field}[]: {len(value)}")
+                for index, item in enumerate(value):
+                    item_field = f"{field}[{index}]"
+                    if isinstance(item, Mapping):
+                        lines.extend(_flatten_lines(item, item_field))
+                    else:
+                        lines.append(f"{item_field}: {_format_scalar(item)}")
+            else:
+                lines.append(f"{field}: {_format_scalar(value)}")
+    else:
+        lines.append(f"value: {_format_scalar(obj)}")
+
+    return lines
+
+
+def json_to_toon(payload: Mapping[str, Any]) -> str:
+    """Return a compact field-path representation suitable for prompt transport.
+
+    This first implementation uses explicit flattened paths so the output remains
+    easy to inspect, benchmark, and map back to SQL-friendly extracted fields.
+    """
+
+    return "\n".join(_flatten_lines(payload))
+
+
+def flatten_query_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract scalar/queryable fields from a JSON object.
+
+    Nested scalar fields are represented with dot paths. Lists are represented by a
+    length field, and scalar lists also get a joined preview value.
+    """
+
+    fields: dict[str, Any] = {}
+
+    def visit(obj: Any, prefix: str = "") -> None:
+        if not isinstance(obj, Mapping):
+            return
+
+        for key, value in obj.items():
+            field = f"{prefix}.{key}" if prefix else str(key)
+            if isinstance(value, Mapping):
+                visit(value, field)
+            elif isinstance(value, list):
+                fields[f"{field}.__len__"] = len(value)
+                if value and all(not isinstance(item, (Mapping, list)) for item in value):
+                    fields[field] = ",".join(str(item) for item in value)
+            else:
+                fields[field] = value
+
+    visit(payload)
+    return fields
+

--- a/src/toonflow/converter.py
+++ b/src/toonflow/converter.py
@@ -105,6 +105,12 @@ def flatten_query_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
                 fields[f"{field}.__len__"] = len(value)
                 if value and all(not isinstance(item, (Mapping, list)) for item in value):
                     fields[field] = ",".join(str(item) for item in value)
+                else:
+                    for index, item in enumerate(value):
+                        if isinstance(item, Mapping):
+                            visit(item, f"{field}[{index}]")
+                        elif not isinstance(item, list):
+                            fields[f"{field}[{index}]"] = item
             else:
                 fields[field] = value
 

--- a/src/toonflow/db.py
+++ b/src/toonflow/db.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class MariaDBConfig:
+    host: str
+    port: int
+    user: str
+    password: str
+    database: str
+
+    def redacted(self) -> dict[str, Any]:
+        return {
+            "host": self.host,
+            "port": self.port,
+            "user": self.user,
+            "password": "***" if self.password else "",
+            "database": self.database,
+        }
+
+
+def load_mariadb_config(env: dict[str, str] | None = None) -> MariaDBConfig:
+    source = env if env is not None else os.environ
+    missing = [
+        name
+        for name in ("TOONFLOW_DB_HOST", "TOONFLOW_DB_USER", "TOONFLOW_DB_PASSWORD", "TOONFLOW_DB_NAME")
+        if not source.get(name)
+    ]
+    if missing:
+        raise ValueError(f"Missing MariaDB config: {', '.join(missing)}")
+
+    return MariaDBConfig(
+        host=source["TOONFLOW_DB_HOST"],
+        port=int(source.get("TOONFLOW_DB_PORT", "3306")),
+        user=source["TOONFLOW_DB_USER"],
+        password=source["TOONFLOW_DB_PASSWORD"],
+        database=source["TOONFLOW_DB_NAME"],
+    )
+
+
+def connect_mariadb(config: MariaDBConfig | None = None) -> Any:
+    try:
+        import mariadb
+    except ImportError as exc:
+        raise RuntimeError(
+            "MariaDB connector is not installed. Install MariaDB Connector/C, then install requirements-mariadb.txt."
+        ) from exc
+
+    cfg = config or load_mariadb_config()
+    return mariadb.connect(
+        host=cfg.host,
+        port=cfg.port,
+        user=cfg.user,
+        password=cfg.password,
+        database=cfg.database,
+    )

--- a/src/toonflow/evaluator.py
+++ b/src/toonflow/evaluator.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .benchmark import benchmark_payload
+from .converter import flatten_query_fields, json_to_toon
+from .validator import validate_payload
+
+
+def evaluate_payload(payload: dict[str, Any], payload_name: str = "payload") -> dict[str, Any]:
+    """Build the demo/evaluator response for one pasted JSON payload."""
+
+    validation = validate_payload(payload)
+    if not validation.ok:
+        return {
+            "status": "rejected",
+            "validation": {
+                "ok": False,
+                "errors": validation.errors,
+                "warnings": validation.warnings,
+            },
+            "toon_payload": "",
+            "extracted_fields": {},
+            "metrics": None,
+        }
+
+    metrics = benchmark_payload(payload, payload_name)
+    return {
+        "status": "ready",
+        "validation": {
+            "ok": True,
+            "errors": validation.errors,
+            "warnings": validation.warnings,
+        },
+        "toon_payload": json_to_toon(payload),
+        "extracted_fields": flatten_query_fields(payload),
+        "metrics": metrics.to_dict(),
+    }

--- a/src/toonflow/mariadb_repository.py
+++ b/src/toonflow/mariadb_repository.py
@@ -4,7 +4,13 @@ import json
 from typing import Any
 
 from .models import IngestRecord
-from .storage import SCHEMA_SQL, build_field_insert_statement, build_field_rows, build_insert_statement
+from .storage import (
+    SCHEMA_SQL,
+    build_delete_fields_statement,
+    build_field_insert_statement,
+    build_field_rows,
+    build_insert_statement,
+)
 
 
 class MariaDBRecordRepository:
@@ -25,6 +31,8 @@ class MariaDBRecordRepository:
         sql, params = build_insert_statement(record)
         with self.connection.cursor() as cursor:
             cursor.execute(sql, params)
+            delete_sql, delete_params = build_delete_fields_statement(record.payload_id)
+            cursor.execute(delete_sql, delete_params)
             for row in build_field_rows(record):
                 field_sql, field_params = build_field_insert_statement(row)
                 cursor.execute(field_sql, field_params)
@@ -57,11 +65,47 @@ class MariaDBRecordRepository:
             rows = cursor.fetchall()
         return [_row_to_dict(row) for row in rows]
 
+    def find_by_field(self, field_path: str, value: Any) -> list[dict[str, Any]]:
+        sql = """
+        SELECT r.payload_id, r.source, r.original_json, r.toon_payload, r.extracted_fields,
+               r.status, r.validation_errors, r.validation_warnings, r.created_at
+        FROM toon_records r
+        JOIN toon_record_fields f ON f.payload_id = r.payload_id
+        WHERE f.field_path = %s
+          AND (
+              f.value_string = %s
+              OR f.value_number = %s
+              OR f.value_boolean = %s
+          )
+        ORDER BY r.created_at DESC
+        """.strip()
+        number_value = _as_float(value)
+        bool_value = _as_bool(value)
+        with self.connection.cursor() as cursor:
+            cursor.execute(sql, (field_path, str(value), number_value, bool_value))
+            rows = cursor.fetchall()
+        return [_row_to_dict(row) for row in rows]
+
 
 def _loads(value: Any) -> Any:
     if isinstance(value, str):
         return json.loads(value)
     return value
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str) and value.lower() in {"true", "false"}:
+        return value.lower() == "true"
+    return None
 
 
 def _row_to_dict(row: tuple[Any, ...]) -> dict[str, Any]:

--- a/src/toonflow/mariadb_repository.py
+++ b/src/toonflow/mariadb_repository.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .models import IngestRecord
+from .storage import SCHEMA_SQL, build_insert_statement
+
+
+class MariaDBRecordRepository:
+    """Repository adapter for MariaDB Connector/Python style connections."""
+
+    def __init__(self, connection: Any) -> None:
+        self.connection = connection
+
+    def create_schema(self) -> None:
+        with self.connection.cursor() as cursor:
+            cursor.execute(SCHEMA_SQL)
+        self.connection.commit()
+
+    def save(self, record: IngestRecord) -> IngestRecord:
+        sql, params = build_insert_statement(record)
+        with self.connection.cursor() as cursor:
+            cursor.execute(sql, params)
+        self.connection.commit()
+        return record
+
+    def get(self, payload_id: str) -> dict[str, Any] | None:
+        sql = """
+        SELECT payload_id, source, original_json, toon_payload, extracted_fields,
+               status, validation_errors, validation_warnings, created_at
+        FROM toon_records
+        WHERE payload_id = %s
+        """.strip()
+        with self.connection.cursor() as cursor:
+            cursor.execute(sql, (payload_id,))
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return _row_to_dict(row)
+
+    def list(self) -> list[dict[str, Any]]:
+        sql = """
+        SELECT payload_id, source, original_json, toon_payload, extracted_fields,
+               status, validation_errors, validation_warnings, created_at
+        FROM toon_records
+        ORDER BY created_at DESC
+        """.strip()
+        with self.connection.cursor() as cursor:
+            cursor.execute(sql)
+            rows = cursor.fetchall()
+        return [_row_to_dict(row) for row in rows]
+
+
+def _loads(value: Any) -> Any:
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def _row_to_dict(row: tuple[Any, ...]) -> dict[str, Any]:
+    return {
+        'payload_id': row[0],
+        'source': row[1],
+        'json': _loads(row[2]),
+        'toon': row[3],
+        'extracted_fields': _loads(row[4]),
+        'status': row[5],
+        'validation_errors': _loads(row[6]),
+        'validation_warnings': _loads(row[7]),
+        'created_at': row[8].isoformat() if hasattr(row[8], 'isoformat') else str(row[8]),
+    }

--- a/src/toonflow/mariadb_repository.py
+++ b/src/toonflow/mariadb_repository.py
@@ -10,6 +10,7 @@ from .storage import (
     build_field_insert_statement,
     build_field_rows,
     build_insert_statement,
+    schema_statements,
 )
 
 
@@ -20,24 +21,30 @@ class MariaDBRecordRepository:
         self.connection = connection
 
     def create_schema(self) -> None:
-        with self.connection.cursor() as cursor:
-            for statement in SCHEMA_SQL.split(";\n"):
-                statement = statement.strip()
-                if statement:
+        try:
+            with self.connection.cursor() as cursor:
+                for statement in schema_statements():
                     cursor.execute(statement)
-        self.connection.commit()
+            self.connection.commit()
+        except Exception:
+            self._rollback_if_supported()
+            raise
 
     def save(self, record: IngestRecord) -> IngestRecord:
-        sql, params = build_insert_statement(record)
-        with self.connection.cursor() as cursor:
-            cursor.execute(sql, params)
-            delete_sql, delete_params = build_delete_fields_statement(record.payload_id)
-            cursor.execute(delete_sql, delete_params)
-            for row in build_field_rows(record):
-                field_sql, field_params = build_field_insert_statement(row)
-                cursor.execute(field_sql, field_params)
-        self.connection.commit()
-        return record
+        try:
+            sql, params = build_insert_statement(record)
+            with self.connection.cursor() as cursor:
+                cursor.execute(sql, params)
+                delete_sql, delete_params = build_delete_fields_statement(record.payload_id)
+                cursor.execute(delete_sql, delete_params)
+                for row in build_field_rows(record):
+                    field_sql, field_params = build_field_insert_statement(row)
+                    cursor.execute(field_sql, field_params)
+            self.connection.commit()
+            return record
+        except Exception:
+            self._rollback_if_supported()
+            raise
 
     def get(self, payload_id: str) -> dict[str, Any] | None:
         sql = """
@@ -85,6 +92,10 @@ class MariaDBRecordRepository:
             cursor.execute(sql, (field_path, str(value), number_value, bool_value))
             rows = cursor.fetchall()
         return [_row_to_dict(row) for row in rows]
+
+    def _rollback_if_supported(self) -> None:
+        if hasattr(self.connection, "rollback"):
+            self.connection.rollback()
 
 
 def _loads(value: Any) -> Any:

--- a/src/toonflow/mariadb_repository.py
+++ b/src/toonflow/mariadb_repository.py
@@ -83,13 +83,15 @@ class MariaDBRecordRepository:
               f.value_string = %s
               OR f.value_number = %s
               OR f.value_boolean = %s
+              OR (%s AND f.value_string IS NULL AND f.value_number IS NULL AND f.value_boolean IS NULL)
           )
         ORDER BY r.created_at DESC
         """.strip()
+        string_value = None if value is None else str(value)
         number_value = _as_float(value)
         bool_value = _as_bool(value)
         with self.connection.cursor() as cursor:
-            cursor.execute(sql, (field_path, str(value), number_value, bool_value))
+            cursor.execute(sql, (field_path, string_value, number_value, bool_value, value is None))
             rows = cursor.fetchall()
         return [_row_to_dict(row) for row in rows]
 

--- a/src/toonflow/mariadb_repository.py
+++ b/src/toonflow/mariadb_repository.py
@@ -4,7 +4,7 @@ import json
 from typing import Any
 
 from .models import IngestRecord
-from .storage import SCHEMA_SQL, build_insert_statement
+from .storage import SCHEMA_SQL, build_field_insert_statement, build_field_rows, build_insert_statement
 
 
 class MariaDBRecordRepository:
@@ -15,13 +15,19 @@ class MariaDBRecordRepository:
 
     def create_schema(self) -> None:
         with self.connection.cursor() as cursor:
-            cursor.execute(SCHEMA_SQL)
+            for statement in SCHEMA_SQL.split(";\n"):
+                statement = statement.strip()
+                if statement:
+                    cursor.execute(statement)
         self.connection.commit()
 
     def save(self, record: IngestRecord) -> IngestRecord:
         sql, params = build_insert_statement(record)
         with self.connection.cursor() as cursor:
             cursor.execute(sql, params)
+            for row in build_field_rows(record):
+                field_sql, field_params = build_field_insert_statement(row)
+                cursor.execute(field_sql, field_params)
         self.connection.commit()
         return record
 

--- a/src/toonflow/models.py
+++ b/src/toonflow/models.py
@@ -12,7 +12,7 @@ def utc_now() -> datetime:
 @dataclass(slots=True)
 class IngestRequest:
     source: str
-    payload: dict[str, Any]
+    payload: Any
     payload_id: str | None = None
     received_at: datetime = field(default_factory=utc_now)
 
@@ -29,11 +29,10 @@ class ValidationResult:
 class IngestRecord:
     payload_id: str
     source: str
-    original_json: dict[str, Any]
+    original_json: Any
     toon_payload: str
     extracted_fields: dict[str, Any]
     status: str
     validation_errors: list[str] = field(default_factory=list)
     validation_warnings: list[str] = field(default_factory=list)
     created_at: datetime = field(default_factory=utc_now)
-

--- a/src/toonflow/models.py
+++ b/src/toonflow/models.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(slots=True)
+class IngestRequest:
+    source: str
+    payload: dict[str, Any]
+    payload_id: str | None = None
+    received_at: datetime = field(default_factory=utc_now)
+
+
+@dataclass(slots=True)
+class ValidationResult:
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    record_count: int = 0
+
+
+@dataclass(slots=True)
+class IngestRecord:
+    payload_id: str
+    source: str
+    original_json: dict[str, Any]
+    toon_payload: str
+    extracted_fields: dict[str, Any]
+    status: str
+    validation_errors: list[str] = field(default_factory=list)
+    validation_warnings: list[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=utc_now)
+

--- a/src/toonflow/query.py
+++ b/src/toonflow/query.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from .models import IngestRecord
+
+
+SUPPORTED_OPERATORS = {"eq", "contains", "gt", "gte", "lt", "lte"}
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def field_matches(actual: Any, expected: Any, operator: str = "eq") -> bool:
+    if operator not in SUPPORTED_OPERATORS:
+        raise ValueError(f"Unsupported operator: {operator}")
+
+    if operator == "eq":
+        return str(actual) == str(expected)
+    if operator == "contains":
+        return str(expected).lower() in str(actual).lower()
+
+    actual_number = _as_float(actual)
+    expected_number = _as_float(expected)
+    if actual_number is None or expected_number is None:
+        return False
+    if operator == "gt":
+        return actual_number > expected_number
+    if operator == "gte":
+        return actual_number >= expected_number
+    if operator == "lt":
+        return actual_number < expected_number
+    return actual_number <= expected_number
+
+
+def query_records(
+    records: Iterable[IngestRecord],
+    field: str,
+    value: Any,
+    operator: str = "eq",
+) -> list[IngestRecord]:
+    return [
+        record
+        for record in records
+        if field in record.extracted_fields
+        and field_matches(record.extracted_fields[field], value, operator)
+    ]
+
+
+def build_sql_preview(field: str, operator: str = "eq") -> dict[str, Any]:
+    if operator not in SUPPORTED_OPERATORS:
+        raise ValueError(f"Unsupported operator: {operator}")
+
+    json_path = '$."' + field.replace('"', '\\"') + '"'
+    extracted_value = "JSON_UNQUOTE(JSON_EXTRACT(extracted_fields, %s))"
+    op_map = {
+        "eq": "=",
+        "contains": "LIKE",
+        "gt": ">",
+        "gte": ">=",
+        "lt": "<",
+        "lte": "<=",
+    }
+    comparator = op_map[operator]
+    sql = f"""
+    SELECT payload_id, source, toon_payload, extracted_fields
+    FROM toon_records
+    WHERE {extracted_value} {comparator} %s
+    ORDER BY created_at DESC
+    """.strip()
+    return {
+        "sql": sql,
+        "params": [json_path, "%value%" if operator == "contains" else "value"],
+        "note": "Preview only; the demo query uses extracted fields, then returns the TOON payload for downstream AI context.",
+    }
+
+
+def hybrid_query_response(
+    records: Iterable[IngestRecord],
+    field: str,
+    value: Any,
+    operator: str = "eq",
+) -> dict[str, Any]:
+    matches = query_records(records, field, value, operator)
+    return {
+        "query": {"field": field, "operator": operator, "value": value},
+        "sql_preview": build_sql_preview(field, operator),
+        "matched_count": len(matches),
+        "records": [
+            {
+                "payload_id": record.payload_id,
+                "source": record.source,
+                "status": record.status,
+                "matched_value": record.extracted_fields.get(field),
+                "toon_payload": record.toon_payload,
+                "extracted_fields": record.extracted_fields,
+            }
+            for record in matches
+        ],
+    }

--- a/src/toonflow/repository.py
+++ b/src/toonflow/repository.py
@@ -21,9 +21,18 @@ class InMemoryRecordStore:
     def list(self) -> list[IngestRecord]:
         return list(self._records.values())
 
+    def find_by_field(self, field: str, value: str) -> list[IngestRecord]:
+        return [
+            record
+            for record in self._records.values()
+            if str(record.extracted_fields.get(field)) == value
+        ]
+
     def save_many(self, records: Iterable[IngestRecord]) -> list[IngestRecord]:
         saved: list[IngestRecord] = []
         for record in records:
             saved.append(self.save(record))
         return saved
 
+    def clear(self) -> None:
+        self._records.clear()

--- a/src/toonflow/repository.py
+++ b/src/toonflow/repository.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .models import IngestRecord
+
+
+class InMemoryRecordStore:
+    """Small repository used by the demo/API before MariaDB is wired in."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, IngestRecord] = {}
+
+    def save(self, record: IngestRecord) -> IngestRecord:
+        self._records[record.payload_id] = record
+        return record
+
+    def get(self, payload_id: str) -> IngestRecord | None:
+        return self._records.get(payload_id)
+
+    def list(self) -> list[IngestRecord]:
+        return list(self._records.values())
+
+    def save_many(self, records: Iterable[IngestRecord]) -> list[IngestRecord]:
+        saved: list[IngestRecord] = []
+        for record in records:
+            saved.append(self.save(record))
+        return saved
+

--- a/src/toonflow/schema.sql
+++ b/src/toonflow/schema.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS toon_records (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    payload_id VARCHAR(128) NOT NULL UNIQUE,
+    source VARCHAR(128) NOT NULL,
+    original_json JSON NOT NULL,
+    toon_payload LONGTEXT NOT NULL,
+    extracted_fields JSON NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    validation_errors JSON NOT NULL,
+    validation_warnings JSON NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    INDEX idx_payload_id (payload_id),
+    INDEX idx_source (source),
+    INDEX idx_status (status),
+    INDEX idx_created_at (created_at)
+);

--- a/src/toonflow/schema.sql
+++ b/src/toonflow/schema.sql
@@ -14,3 +14,20 @@ CREATE TABLE IF NOT EXISTS toon_records (
     INDEX idx_status (status),
     INDEX idx_created_at (created_at)
 );
+
+CREATE TABLE IF NOT EXISTS toon_record_fields (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    payload_id VARCHAR(128) NOT NULL,
+    field_path VARCHAR(255) NOT NULL,
+    value_string TEXT NULL,
+    value_number DOUBLE NULL,
+    value_boolean BOOLEAN NULL,
+    created_at DATETIME(6) NOT NULL,
+    INDEX idx_field_path (field_path),
+    INDEX idx_payload_field (payload_id, field_path),
+    INDEX idx_field_string (field_path, value_string(191)),
+    INDEX idx_field_number (field_path, value_number),
+    CONSTRAINT fk_toon_record_fields_payload
+        FOREIGN KEY (payload_id) REFERENCES toon_records(payload_id)
+        ON DELETE CASCADE
+);

--- a/src/toonflow/service.py
+++ b/src/toonflow/service.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Protocol
 from uuid import uuid4
 
 from .converter import flatten_query_fields, json_to_toon
 from .models import IngestRecord, IngestRequest
 from .storage import build_export_payload
 from .validator import validate_payload
+
+
+class RecordRepository(Protocol):
+    def save(self, record: IngestRecord) -> IngestRecord: ...
 
 
 def build_ingest_record(request: IngestRequest) -> IngestRecord:
@@ -45,6 +49,39 @@ def ingest_payload(payload: dict[str, Any], source: str = 'api', payload_id: str
     request = IngestRequest(source=source, payload=payload, payload_id=payload_id)
     record = build_ingest_record(request)
     return summarize_record(record)
+
+
+def ingest_and_store_payload(
+    payload: dict[str, Any],
+    repository: RecordRepository,
+    source: str = 'pipeline',
+    payload_id: str | None = None,
+) -> dict[str, Any]:
+    request = IngestRequest(source=source, payload=payload, payload_id=payload_id)
+    record = build_ingest_record(request)
+    repository.save(record)
+    result = summarize_record(record)
+    result['stored'] = True
+    return result
+
+
+def batch_ingest_and_store_payloads(
+    payloads: list[dict[str, Any]],
+    repository: RecordRepository,
+    source: str = 'pipeline-batch',
+) -> dict[str, Any]:
+    records = build_batch_records(payloads, source=source)
+    for record in records:
+        repository.save(record)
+    accepted = [record for record in records if record.status == 'validated']
+    rejected = [record for record in records if record.status == 'rejected']
+    return {
+        'total': len(records),
+        'accepted': len(accepted),
+        'rejected': len(rejected),
+        'stored': len(records),
+        'records': [summarize_record(record) for record in records],
+    }
 
 
 def validate_only(payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/toonflow/service.py
+++ b/src/toonflow/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Protocol
 from uuid import uuid4
 
@@ -13,16 +14,29 @@ class RecordRepository(Protocol):
     def save(self, record: IngestRecord) -> IngestRecord: ...
 
 
+def _resolve_payload_id(payload: Any, explicit_payload_id: str | None) -> str:
+    if explicit_payload_id:
+        return explicit_payload_id
+    payload_id = payload.get('id') if isinstance(payload, Mapping) else None
+    if isinstance(payload_id, str) and payload_id:
+        return payload_id
+    return str(uuid4())
+
+
+def _copy_payload_for_audit(payload: Any) -> Any:
+    return dict(payload) if isinstance(payload, Mapping) else payload
+
+
 def build_ingest_record(request: IngestRequest) -> IngestRecord:
     validation = validate_payload(request.payload)
-    payload_id = request.payload_id or request.payload.get('id') or str(uuid4())
+    payload_id = _resolve_payload_id(request.payload, request.payload_id)
     toon_payload = json_to_toon(request.payload) if validation.ok else ''
     extracted_fields = flatten_query_fields(request.payload) if validation.ok else {}
     status = 'validated' if validation.ok else 'rejected'
     return IngestRecord(
         payload_id=payload_id,
         source=request.source,
-        original_json=dict(request.payload),
+        original_json=_copy_payload_for_audit(request.payload),
         toon_payload=toon_payload,
         extracted_fields=extracted_fields,
         status=status,

--- a/src/toonflow/service.py
+++ b/src/toonflow/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from typing import Any, Protocol
 from uuid import uuid4
@@ -24,7 +25,15 @@ def _resolve_payload_id(payload: Any, explicit_payload_id: str | None) -> str:
 
 
 def _copy_payload_for_audit(payload: Any) -> Any:
-    return dict(payload) if isinstance(payload, Mapping) else payload
+    copied_payload = dict(payload) if isinstance(payload, Mapping) else payload
+    try:
+        json.dumps(copied_payload, allow_nan=False)
+    except (TypeError, ValueError):
+        return {
+            "_audit_note": "Payload was not strict JSON serialisable; stored repr for audit.",
+            "raw_repr": repr(payload),
+        }
+    return copied_payload
 
 
 def build_ingest_record(request: IngestRequest) -> IngestRecord:
@@ -59,14 +68,14 @@ def summarize_record(record: IngestRecord) -> dict[str, Any]:
     }
 
 
-def ingest_payload(payload: dict[str, Any], source: str = 'api', payload_id: str | None = None) -> dict[str, Any]:
+def ingest_payload(payload: Any, source: str = 'api', payload_id: str | None = None) -> dict[str, Any]:
     request = IngestRequest(source=source, payload=payload, payload_id=payload_id)
     record = build_ingest_record(request)
     return summarize_record(record)
 
 
 def ingest_and_store_payload(
-    payload: dict[str, Any],
+    payload: Any,
     repository: RecordRepository,
     source: str = 'pipeline',
     payload_id: str | None = None,
@@ -80,7 +89,7 @@ def ingest_and_store_payload(
 
 
 def batch_ingest_and_store_payloads(
-    payloads: list[dict[str, Any]],
+    payloads: list[Any],
     repository: RecordRepository,
     source: str = 'pipeline-batch',
 ) -> dict[str, Any]:
@@ -98,7 +107,7 @@ def batch_ingest_and_store_payloads(
     }
 
 
-def validate_only(payload: dict[str, Any]) -> dict[str, Any]:
+def validate_only(payload: Any) -> dict[str, Any]:
     result = validate_payload(payload)
     return {
         'ok': result.ok,
@@ -108,7 +117,7 @@ def validate_only(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def convert_only(payload: dict[str, Any]) -> dict[str, Any]:
+def convert_only(payload: Any) -> dict[str, Any]:
     validation = validate_payload(payload)
     if not validation.ok:
         return {
@@ -126,7 +135,7 @@ def convert_only(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def batch_ingest_payloads(payloads: list[dict[str, Any]], source: str = 'batch') -> dict[str, Any]:
+def batch_ingest_payloads(payloads: list[Any], source: str = 'batch') -> dict[str, Any]:
     records = build_batch_records(payloads, source=source)
     accepted = [record for record in records if record.status == 'validated']
     rejected = [record for record in records if record.status == 'rejected']
@@ -138,7 +147,7 @@ def batch_ingest_payloads(payloads: list[dict[str, Any]], source: str = 'batch')
     }
 
 
-def build_batch_records(payloads: list[dict[str, Any]], source: str = 'batch') -> list[IngestRecord]:
+def build_batch_records(payloads: list[Any], source: str = 'batch') -> list[IngestRecord]:
     return [build_ingest_record(IngestRequest(source=source, payload=payload)) for payload in payloads]
 
 

--- a/src/toonflow/service.py
+++ b/src/toonflow/service.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from .converter import flatten_query_fields, json_to_toon
+from .models import IngestRecord, IngestRequest
+from .validator import validate_payload
+
+
+def build_ingest_record(request: IngestRequest) -> IngestRecord:
+    validation = validate_payload(request.payload)
+    payload_id = request.payload_id or request.payload.get('id') or str(uuid4())
+    toon_payload = json_to_toon(request.payload) if validation.ok else ''
+    extracted_fields = flatten_query_fields(request.payload) if validation.ok else {}
+    status = 'validated' if validation.ok else 'rejected'
+    return IngestRecord(
+        payload_id=payload_id,
+        source=request.source,
+        original_json=dict(request.payload),
+        toon_payload=toon_payload,
+        extracted_fields=extracted_fields,
+        status=status,
+        validation_errors=validation.errors,
+        validation_warnings=validation.warnings,
+        created_at=request.received_at,
+    )
+
+
+def ingest_payload(payload: dict[str, Any], source: str = 'api', payload_id: str | None = None) -> dict[str, Any]:
+    request = IngestRequest(source=source, payload=payload, payload_id=payload_id)
+    record = build_ingest_record(request)
+    return {
+        'payload_id': record.payload_id,
+        'status': record.status,
+        'toon_payload': record.toon_payload,
+        'extracted_fields': record.extracted_fields,
+        'validation_errors': record.validation_errors,
+        'validation_warnings': record.validation_warnings,
+    }

--- a/src/toonflow/service.py
+++ b/src/toonflow/service.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from .converter import flatten_query_fields, json_to_toon
 from .models import IngestRecord, IngestRequest
+from .storage import build_export_payload
 from .validator import validate_payload
 
 
@@ -27,14 +28,68 @@ def build_ingest_record(request: IngestRequest) -> IngestRecord:
     )
 
 
-def ingest_payload(payload: dict[str, Any], source: str = 'api', payload_id: str | None = None) -> dict[str, Any]:
-    request = IngestRequest(source=source, payload=payload, payload_id=payload_id)
-    record = build_ingest_record(request)
+def summarize_record(record: IngestRecord) -> dict[str, Any]:
     return {
         'payload_id': record.payload_id,
+        'source': record.source,
         'status': record.status,
         'toon_payload': record.toon_payload,
         'extracted_fields': record.extracted_fields,
         'validation_errors': record.validation_errors,
         'validation_warnings': record.validation_warnings,
+        'created_at': record.created_at.isoformat(),
     }
+
+
+def ingest_payload(payload: dict[str, Any], source: str = 'api', payload_id: str | None = None) -> dict[str, Any]:
+    request = IngestRequest(source=source, payload=payload, payload_id=payload_id)
+    record = build_ingest_record(request)
+    return summarize_record(record)
+
+
+def validate_only(payload: dict[str, Any]) -> dict[str, Any]:
+    result = validate_payload(payload)
+    return {
+        'ok': result.ok,
+        'errors': result.errors,
+        'warnings': result.warnings,
+        'record_count': result.record_count,
+    }
+
+
+def convert_only(payload: dict[str, Any]) -> dict[str, Any]:
+    validation = validate_payload(payload)
+    if not validation.ok:
+        return {
+            'status': 'rejected',
+            'toon_payload': '',
+            'validation_errors': validation.errors,
+            'validation_warnings': validation.warnings,
+        }
+    return {
+        'status': 'converted',
+        'toon_payload': json_to_toon(payload),
+        'extracted_fields': flatten_query_fields(payload),
+        'validation_errors': validation.errors,
+        'validation_warnings': validation.warnings,
+    }
+
+
+def batch_ingest_payloads(payloads: list[dict[str, Any]], source: str = 'batch') -> dict[str, Any]:
+    records = build_batch_records(payloads, source=source)
+    accepted = [record for record in records if record.status == 'validated']
+    rejected = [record for record in records if record.status == 'rejected']
+    return {
+        'total': len(records),
+        'accepted': len(accepted),
+        'rejected': len(rejected),
+        'records': [summarize_record(record) for record in records],
+    }
+
+
+def build_batch_records(payloads: list[dict[str, Any]], source: str = 'batch') -> list[IngestRecord]:
+    return [build_ingest_record(IngestRequest(source=source, payload=payload)) for payload in payloads]
+
+
+def export_record(record: IngestRecord) -> dict[str, Any]:
+    return build_export_payload(record)

--- a/src/toonflow/storage.py
+++ b/src/toonflow/storage.py
@@ -43,6 +43,10 @@ CREATE TABLE IF NOT EXISTS toon_record_fields (
 """.strip()
 
 
+def schema_statements() -> list[str]:
+    return [statement.strip() for statement in SCHEMA_SQL.split(";\n") if statement.strip()]
+
+
 def build_insert_statement(record: IngestRecord) -> tuple[str, tuple[Any, ...]]:
     sql = """
     INSERT INTO toon_records (
@@ -147,21 +151,29 @@ def build_export_payload(record: IngestRecord) -> dict[str, Any]:
 
 
 def create_schema(connection: Any) -> None:
-    with connection.cursor() as cursor:
-        for statement in SCHEMA_SQL.split(";\n"):
-            statement = statement.strip()
-            if statement:
+    try:
+        with connection.cursor() as cursor:
+            for statement in schema_statements():
                 cursor.execute(statement)
-    connection.commit()
+        connection.commit()
+    except Exception:
+        if hasattr(connection, "rollback"):
+            connection.rollback()
+        raise
 
 
 def store_record(connection: Any, record: IngestRecord) -> None:
-    sql, params = build_insert_statement(record)
-    with connection.cursor() as cursor:
-        cursor.execute(sql, params)
-        delete_sql, delete_params = build_delete_fields_statement(record.payload_id)
-        cursor.execute(delete_sql, delete_params)
-        for row in build_field_rows(record):
-            field_sql, field_params = build_field_insert_statement(row)
-            cursor.execute(field_sql, field_params)
-    connection.commit()
+    try:
+        sql, params = build_insert_statement(record)
+        with connection.cursor() as cursor:
+            cursor.execute(sql, params)
+            delete_sql, delete_params = build_delete_fields_statement(record.payload_id)
+            cursor.execute(delete_sql, delete_params)
+            for row in build_field_rows(record):
+                field_sql, field_params = build_field_insert_statement(row)
+                cursor.execute(field_sql, field_params)
+        connection.commit()
+    except Exception:
+        if hasattr(connection, "rollback"):
+            connection.rollback()
+        raise

--- a/src/toonflow/storage.py
+++ b/src/toonflow/storage.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .models import IngestRecord
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS toon_records (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    payload_id VARCHAR(128) NOT NULL UNIQUE,
+    source VARCHAR(128) NOT NULL,
+    original_json JSON NOT NULL,
+    toon_payload LONGTEXT NOT NULL,
+    extracted_fields JSON NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    validation_errors JSON NOT NULL,
+    validation_warnings JSON NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    INDEX idx_payload_id (payload_id),
+    INDEX idx_source (source),
+    INDEX idx_status (status),
+    INDEX idx_created_at (created_at)
+);
+""".strip()
+
+
+def build_insert_statement(record: IngestRecord) -> tuple[str, tuple[Any, ...]]:
+    sql = """
+    INSERT INTO toon_records (
+        payload_id,
+        source,
+        original_json,
+        toon_payload,
+        extracted_fields,
+        status,
+        validation_errors,
+        validation_warnings,
+        created_at
+    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+    """.strip()
+
+    params = (
+        record.payload_id,
+        record.source,
+        json.dumps(record.original_json, ensure_ascii=False, separators=(",", ":")),
+        record.toon_payload,
+        json.dumps(record.extracted_fields, ensure_ascii=False, separators=(",", ":")),
+        record.status,
+        json.dumps(record.validation_errors, ensure_ascii=False),
+        json.dumps(record.validation_warnings, ensure_ascii=False),
+        record.created_at.replace(tzinfo=None),
+    )
+    return sql, params
+
+
+def build_export_payload(record: IngestRecord) -> dict[str, Any]:
+    return {
+        "payload_id": record.payload_id,
+        "source": record.source,
+        "status": record.status,
+        "json": record.original_json,
+        "toon": record.toon_payload,
+        "extracted_fields": record.extracted_fields,
+        "validation": {
+            "errors": record.validation_errors,
+            "warnings": record.validation_warnings,
+        },
+        "created_at": record.created_at.isoformat(),
+    }
+
+
+def create_schema(connection: Any) -> None:
+    with connection.cursor() as cursor:
+        cursor.execute(SCHEMA_SQL)
+    connection.commit()
+
+
+def store_record(connection: Any, record: IngestRecord) -> None:
+    sql, params = build_insert_statement(record)
+    with connection.cursor() as cursor:
+        cursor.execute(sql, params)
+    connection.commit()
+

--- a/src/toonflow/storage.py
+++ b/src/toonflow/storage.py
@@ -47,6 +47,10 @@ def schema_statements() -> list[str]:
     return [statement.strip() for statement in SCHEMA_SQL.split(";\n") if statement.strip()]
 
 
+def dumps_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), allow_nan=False)
+
+
 def build_insert_statement(record: IngestRecord) -> tuple[str, tuple[Any, ...]]:
     sql = """
     INSERT INTO toon_records (
@@ -74,12 +78,12 @@ def build_insert_statement(record: IngestRecord) -> tuple[str, tuple[Any, ...]]:
     params = (
         record.payload_id,
         record.source,
-        json.dumps(record.original_json, ensure_ascii=False, separators=(",", ":")),
+        dumps_json(record.original_json),
         record.toon_payload,
-        json.dumps(record.extracted_fields, ensure_ascii=False, separators=(",", ":")),
+        dumps_json(record.extracted_fields),
         record.status,
-        json.dumps(record.validation_errors, ensure_ascii=False),
-        json.dumps(record.validation_warnings, ensure_ascii=False),
+        dumps_json(record.validation_errors),
+        dumps_json(record.validation_warnings),
         record.created_at.replace(tzinfo=None),
     )
     return sql, params

--- a/src/toonflow/storage.py
+++ b/src/toonflow/storage.py
@@ -56,6 +56,15 @@ def build_insert_statement(record: IngestRecord) -> tuple[str, tuple[Any, ...]]:
         validation_warnings,
         created_at
     ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+    ON DUPLICATE KEY UPDATE
+        source = VALUES(source),
+        original_json = VALUES(original_json),
+        toon_payload = VALUES(toon_payload),
+        extracted_fields = VALUES(extracted_fields),
+        status = VALUES(status),
+        validation_errors = VALUES(validation_errors),
+        validation_warnings = VALUES(validation_warnings),
+        created_at = VALUES(created_at)
     """.strip()
 
     params = (
@@ -70,6 +79,10 @@ def build_insert_statement(record: IngestRecord) -> tuple[str, tuple[Any, ...]]:
         record.created_at.replace(tzinfo=None),
     )
     return sql, params
+
+
+def build_delete_fields_statement(payload_id: str) -> tuple[str, tuple[Any, ...]]:
+    return "DELETE FROM toon_record_fields WHERE payload_id = %s", (payload_id,)
 
 
 def build_field_rows(record: IngestRecord) -> list[dict[str, Any]]:
@@ -146,6 +159,8 @@ def store_record(connection: Any, record: IngestRecord) -> None:
     sql, params = build_insert_statement(record)
     with connection.cursor() as cursor:
         cursor.execute(sql, params)
+        delete_sql, delete_params = build_delete_fields_statement(record.payload_id)
+        cursor.execute(delete_sql, delete_params)
         for row in build_field_rows(record):
             field_sql, field_params = build_field_insert_statement(row)
             cursor.execute(field_sql, field_params)

--- a/src/toonflow/storage.py
+++ b/src/toonflow/storage.py
@@ -23,6 +23,23 @@ CREATE TABLE IF NOT EXISTS toon_records (
     INDEX idx_status (status),
     INDEX idx_created_at (created_at)
 );
+
+CREATE TABLE IF NOT EXISTS toon_record_fields (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    payload_id VARCHAR(128) NOT NULL,
+    field_path VARCHAR(255) NOT NULL,
+    value_string TEXT NULL,
+    value_number DOUBLE NULL,
+    value_boolean BOOLEAN NULL,
+    created_at DATETIME(6) NOT NULL,
+    INDEX idx_field_path (field_path),
+    INDEX idx_payload_field (payload_id, field_path),
+    INDEX idx_field_string (field_path, value_string(191)),
+    INDEX idx_field_number (field_path, value_number),
+    CONSTRAINT fk_toon_record_fields_payload
+        FOREIGN KEY (payload_id) REFERENCES toon_records(payload_id)
+        ON DELETE CASCADE
+);
 """.strip()
 
 
@@ -55,6 +72,51 @@ def build_insert_statement(record: IngestRecord) -> tuple[str, tuple[Any, ...]]:
     return sql, params
 
 
+def build_field_rows(record: IngestRecord) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for field_path, value in record.extracted_fields.items():
+        row = {
+            "payload_id": record.payload_id,
+            "field_path": field_path,
+            "value_string": None,
+            "value_number": None,
+            "value_boolean": None,
+            "created_at": record.created_at.replace(tzinfo=None),
+        }
+        if isinstance(value, bool):
+            row["value_boolean"] = value
+            row["value_string"] = str(value).lower()
+        elif isinstance(value, (int, float)):
+            row["value_number"] = float(value)
+            row["value_string"] = str(value)
+        elif value is not None:
+            row["value_string"] = str(value)
+        rows.append(row)
+    return rows
+
+
+def build_field_insert_statement(row: dict[str, Any]) -> tuple[str, tuple[Any, ...]]:
+    sql = """
+    INSERT INTO toon_record_fields (
+        payload_id,
+        field_path,
+        value_string,
+        value_number,
+        value_boolean,
+        created_at
+    ) VALUES (%s, %s, %s, %s, %s, %s)
+    """.strip()
+    params = (
+        row["payload_id"],
+        row["field_path"],
+        row["value_string"],
+        row["value_number"],
+        row["value_boolean"],
+        row["created_at"],
+    )
+    return sql, params
+
+
 def build_export_payload(record: IngestRecord) -> dict[str, Any]:
     return {
         "payload_id": record.payload_id,
@@ -73,7 +135,10 @@ def build_export_payload(record: IngestRecord) -> dict[str, Any]:
 
 def create_schema(connection: Any) -> None:
     with connection.cursor() as cursor:
-        cursor.execute(SCHEMA_SQL)
+        for statement in SCHEMA_SQL.split(";\n"):
+            statement = statement.strip()
+            if statement:
+                cursor.execute(statement)
     connection.commit()
 
 
@@ -81,5 +146,7 @@ def store_record(connection: Any, record: IngestRecord) -> None:
     sql, params = build_insert_statement(record)
     with connection.cursor() as cursor:
         cursor.execute(sql, params)
+        for row in build_field_rows(record):
+            field_sql, field_params = build_field_insert_statement(row)
+            cursor.execute(field_sql, field_params)
     connection.commit()
-

--- a/src/toonflow/validator.py
+++ b/src/toonflow/validator.py
@@ -5,10 +5,12 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 
+from .converter import flatten_query_fields
 from .models import ValidationResult
 
 
 REQUIRED_TOP_LEVEL_KEYS = ("entity", "timestamp", "data")
+MAX_FIELD_PATH_LENGTH = 255
 
 
 def _is_iso_timestamp(value: str) -> bool:
@@ -62,9 +64,15 @@ def validate_payload(payload: Mapping[str, Any]) -> ValidationResult:
         errors.append("'id' must be a string when provided")
 
     try:
-        json.dumps(payload)
+        json.dumps(payload, allow_nan=False)
     except (TypeError, ValueError):
-        errors.append("Payload must be JSON serialisable")
+        errors.append("Payload must be strict JSON serialisable")
+
+    if not errors:
+        for field_path in flatten_query_fields(payload).keys():
+            if len(field_path) > MAX_FIELD_PATH_LENGTH:
+                errors.append(f"Extracted field path exceeds {MAX_FIELD_PATH_LENGTH} characters: {field_path}")
+                break
 
     record_count = 1 if isinstance(data_obj, Mapping) else 0
     return ValidationResult(ok=not errors, errors=errors, warnings=warnings, record_count=record_count)

--- a/src/toonflow/validator.py
+++ b/src/toonflow/validator.py
@@ -11,6 +11,7 @@ from .models import ValidationResult
 
 REQUIRED_TOP_LEVEL_KEYS = ("entity", "timestamp", "data")
 MAX_FIELD_PATH_LENGTH = 255
+MAX_PAYLOAD_ID_LENGTH = 128
 
 
 def _is_iso_timestamp(value: str) -> bool:
@@ -62,6 +63,8 @@ def validate_payload(payload: Any) -> ValidationResult:
         warnings.append("Payload does not include an 'id'; a generated payload_id will be used")
     elif not isinstance(payload.get("id"), str):
         errors.append("'id' must be a string when provided")
+    elif len(payload["id"]) > MAX_PAYLOAD_ID_LENGTH:
+        errors.append(f"'id' must be {MAX_PAYLOAD_ID_LENGTH} characters or fewer")
 
     try:
         json.dumps(payload, allow_nan=False)

--- a/src/toonflow/validator.py
+++ b/src/toonflow/validator.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 
 from .models import ValidationResult
 
 
 REQUIRED_TOP_LEVEL_KEYS = ("entity", "timestamp", "data")
+
+
+def _is_iso_timestamp(value: str) -> bool:
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
 
 
 def validate_payload(payload: Mapping[str, Any]) -> ValidationResult:
@@ -37,6 +47,8 @@ def validate_payload(payload: Mapping[str, Any]) -> ValidationResult:
         errors.append("'timestamp' must be an ISO-8601 string")
     elif timestamp == "":
         errors.append("'timestamp' cannot be empty")
+    elif isinstance(timestamp, str) and not _is_iso_timestamp(timestamp):
+        errors.append("'timestamp' must be a valid ISO-8601 timestamp")
 
     data_obj = payload.get("data")
     if data_obj is not None and not isinstance(data_obj, Mapping):
@@ -46,7 +58,13 @@ def validate_payload(payload: Mapping[str, Any]) -> ValidationResult:
 
     if payload.get("id") is None:
         warnings.append("Payload does not include an 'id'; a generated payload_id will be used")
+    elif not isinstance(payload.get("id"), str):
+        errors.append("'id' must be a string when provided")
+
+    try:
+        json.dumps(payload)
+    except (TypeError, ValueError):
+        errors.append("Payload must be JSON serialisable")
 
     record_count = 1 if isinstance(data_obj, Mapping) else 0
     return ValidationResult(ok=not errors, errors=errors, warnings=warnings, record_count=record_count)
-

--- a/src/toonflow/validator.py
+++ b/src/toonflow/validator.py
@@ -21,7 +21,7 @@ def _is_iso_timestamp(value: str) -> bool:
     return True
 
 
-def validate_payload(payload: Mapping[str, Any]) -> ValidationResult:
+def validate_payload(payload: Any) -> ValidationResult:
     """Validate the minimum JSON contract used by the first TOONFlow slice.
 
     The validator is intentionally conservative: it does not try to impose a full

--- a/src/toonflow/validator.py
+++ b/src/toonflow/validator.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .models import ValidationResult
+
+
+REQUIRED_TOP_LEVEL_KEYS = ("entity", "timestamp", "data")
+
+
+def validate_payload(payload: Mapping[str, Any]) -> ValidationResult:
+    """Validate the minimum JSON contract used by the first TOONFlow slice.
+
+    The validator is intentionally conservative: it does not try to impose a full
+    business schema yet, but it rejects payloads that cannot be ingested safely.
+    """
+
+    if not isinstance(payload, Mapping):
+        return ValidationResult(ok=False, errors=["Payload must be a JSON object"])
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    for key in REQUIRED_TOP_LEVEL_KEYS:
+        if key not in payload:
+            errors.append(f"Missing required top-level key: {key}")
+
+    entity = payload.get("entity")
+    if entity is not None and not isinstance(entity, str):
+        errors.append("'entity' must be a string")
+    elif entity == "":
+        errors.append("'entity' cannot be empty")
+
+    timestamp = payload.get("timestamp")
+    if timestamp is not None and not isinstance(timestamp, str):
+        errors.append("'timestamp' must be an ISO-8601 string")
+    elif timestamp == "":
+        errors.append("'timestamp' cannot be empty")
+
+    data_obj = payload.get("data")
+    if data_obj is not None and not isinstance(data_obj, Mapping):
+        errors.append("'data' must be a JSON object")
+    elif isinstance(data_obj, Mapping) and len(data_obj) == 0:
+        warnings.append("'data' object is empty")
+
+    if payload.get("id") is None:
+        warnings.append("Payload does not include an 'id'; a generated payload_id will be used")
+
+    record_count = 1 if isinstance(data_obj, Mapping) else 0
+    return ValidationResult(ok=not errors, errors=errors, warnings=warnings, record_count=record_count)
+

--- a/tasks/task-breakdown.md
+++ b/tasks/task-breakdown.md
@@ -19,12 +19,14 @@ All tasks are currently assigned to: **Dominic Low**
 - Record failures and ingestion status
 - Start: 23 Apr 2026
 - Target completion: 24 Apr 2026
+- Implementation status: end-to-end backend path added with accepted/rejected record handling, strict JSON checks, ISO timestamp validation, and audit-friendly error storage.
 
 ### 3. JSON to TOON conversion layer
 - Convert validated JSON payloads to TOON
 - Add conversion tests / sample records
 - Start: 23 Apr 2026
 - Target completion: 24 Apr 2026
+- Implementation status: converter added with compact nested/object-list formatting, scalar list handling, SQL-friendly field extraction, and sample coverage.
 
 ### 4. MariaDB schema and dual-storage design
 - Store TOON payloads
@@ -32,6 +34,7 @@ All tasks are currently assigned to: **Dominic Low**
 - Store metadata
 - Start: 23 Apr 2026
 - Target completion: 24 Apr 2026
+- Implementation status: MariaDB schema added for `toon_records` plus indexed `toon_record_fields`, with repository upsert, field-row refresh, rollback handling, and queryable field rows.
 
 ### 5. Core API endpoints
 - Ingest record

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,15 @@ def test_validate_and_convert_endpoints():
     assert converted.json()['status'] == 'converted'
 
 
+def test_evaluate_endpoint_returns_metrics_and_toon():
+    response = client.post('/evaluate', json=valid_payload())
+    assert response.status_code == 200
+    body = response.json()
+    assert body['status'] == 'ready'
+    assert body['metrics']['json_bytes'] > 0
+    assert body['toon_payload']
+
+
 def test_ingest_read_and_export_flow():
     ingest = client.post('/ingest', json=valid_payload())
     assert ingest.status_code == 200
@@ -37,6 +46,14 @@ def test_ingest_read_and_export_flow():
     exported = client.get(f'/records/{payload_id}/export')
     assert exported.status_code == 200
     assert exported.json()['json']['entity'] == 'invoice'
+
+
+def test_search_records_endpoint_matches_extracted_field():
+    payload = valid_payload() | {'id': 'api-search-001'}
+    assert client.post('/ingest', json=payload).status_code == 200
+    response = client.get('/records/search', params={'field': 'entity', 'value': 'invoice'})
+    assert response.status_code == 200
+    assert any(item['payload_id'] == 'api-search-001' for item in response.json())
 
 
 def test_invalid_ingest_returns_400():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,12 @@ def test_health_endpoint():
     assert response.json() == {'status': 'ok'}
 
 
+def test_demo_page_loads():
+    response = client.get('/demo')
+    assert response.status_code == 200
+    assert 'TOONFlow evaluator' in response.text
+
+
 def test_validate_and_convert_endpoints():
     assert client.post('/validate', json=valid_payload()).json()['ok'] is True
     converted = client.post('/convert', json=valid_payload())
@@ -54,6 +60,17 @@ def test_search_records_endpoint_matches_extracted_field():
     response = client.get('/records/search', params={'field': 'entity', 'value': 'invoice'})
     assert response.status_code == 200
     assert any(item['payload_id'] == 'api-search-001' for item in response.json())
+
+
+def test_query_endpoint_returns_hybrid_results():
+    payload = valid_payload() | {'id': 'api-query-001'}
+    assert client.post('/ingest', json=payload).status_code == 200
+    response = client.post('/query', json={'field': 'entity', 'operator': 'eq', 'value': 'invoice'})
+    assert response.status_code == 200
+    body = response.json()
+    assert body['matched_count'] >= 1
+    assert 'JSON_EXTRACT' in body['sql_preview']['sql']
+    assert any(item['payload_id'] == 'api-query-001' for item in body['records'])
 
 
 def test_invalid_ingest_returns_400():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,53 @@
+from fastapi.testclient import TestClient
+
+from toonflow.api import app
+
+
+client = TestClient(app)
+
+
+def valid_payload():
+    return {
+        'id': 'api-001',
+        'entity': 'invoice',
+        'timestamp': '2026-04-23T12:00:00Z',
+        'data': {'customer': {'name': 'Alice'}, 'amount': 245.50},
+    }
+
+
+def test_health_endpoint():
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert response.json() == {'status': 'ok'}
+
+
+def test_validate_and_convert_endpoints():
+    assert client.post('/validate', json=valid_payload()).json()['ok'] is True
+    converted = client.post('/convert', json=valid_payload())
+    assert converted.status_code == 200
+    assert converted.json()['status'] == 'converted'
+
+
+def test_ingest_read_and_export_flow():
+    ingest = client.post('/ingest', json=valid_payload())
+    assert ingest.status_code == 200
+    payload_id = ingest.json()['payload_id']
+    read = client.get(f'/records/{payload_id}')
+    assert read.status_code == 200
+    exported = client.get(f'/records/{payload_id}/export')
+    assert exported.status_code == 200
+    assert exported.json()['json']['entity'] == 'invoice'
+
+
+def test_invalid_ingest_returns_400():
+    response = client.post('/ingest', json={'entity': 'invoice'})
+    assert response.status_code == 400
+
+
+def test_batch_ingest_endpoint():
+    response = client.post('/batch/ingest', json=[valid_payload(), {'entity': 'invoice'}])
+    assert response.status_code == 200
+    body = response.json()
+    assert body['total'] == 2
+    assert body['accepted'] == 1
+    assert body['rejected'] == 1

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -4,10 +4,12 @@ from toonflow.benchmark import (
     benchmark_payload,
     benchmark_payloads,
     canonical_json,
+    estimate_cost_usd,
     estimate_tokens,
     load_json_payloads,
     percentage_savings,
     write_benchmark_report,
+    write_markdown_report,
 )
 
 
@@ -26,6 +28,7 @@ def test_canonical_json_is_compact_and_stable():
 
 def test_estimate_tokens_and_savings_are_repeatable():
     assert estimate_tokens("abcd") == 1
+    assert estimate_cost_usd(1_000_000, cost_per_million_tokens=0.15) == 0.15
     assert percentage_savings(100, 75) == 25.0
 
 
@@ -35,6 +38,8 @@ def test_benchmark_payload_returns_expected_metric_shape():
     assert result.json_bytes > 0
     assert result.toon_bytes > 0
     assert result.json_token_estimate > 0
+    assert result.json_estimated_cost_usd >= result.toon_estimated_cost_usd
+    assert result.records_per_second >= 0
     assert result.conversion_ms >= 0
 
 
@@ -42,6 +47,8 @@ def test_benchmark_payloads_returns_totals():
     report = benchmark_payloads({"invoice": payload()})
     assert len(report["results"]) == 1
     assert report["totals"]["json_bytes"] >= report["results"][0]["json_bytes"]
+    assert "estimated_cost_savings_usd" in report["totals"]
+    assert "records_per_second" in report["totals"]
 
 
 def test_load_and_write_benchmark_report(tmp_path: Path):
@@ -54,3 +61,7 @@ def test_load_and_write_benchmark_report(tmp_path: Path):
     write_benchmark_report(benchmark_payloads(loaded), output)
     assert output.exists()
     assert "json_bytes" in output.read_text(encoding="utf-8")
+
+    markdown = tmp_path / "report.md"
+    write_markdown_report(benchmark_payloads(loaded), markdown)
+    assert "JSON vs TOON Benchmark Results" in markdown.read_text(encoding="utf-8")

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from toonflow.benchmark import (
+    benchmark_payload,
+    benchmark_payloads,
+    canonical_json,
+    estimate_tokens,
+    load_json_payloads,
+    percentage_savings,
+    write_benchmark_report,
+)
+
+
+def payload():
+    return {
+        "id": "bench-001",
+        "entity": "invoice",
+        "timestamp": "2026-04-23T12:00:00Z",
+        "data": {"customer": {"name": "Alice"}, "amount": 245.5},
+    }
+
+
+def test_canonical_json_is_compact_and_stable():
+    assert canonical_json({"b": 2, "a": 1}) == '{"a":1,"b":2}'
+
+
+def test_estimate_tokens_and_savings_are_repeatable():
+    assert estimate_tokens("abcd") == 1
+    assert percentage_savings(100, 75) == 25.0
+
+
+def test_benchmark_payload_returns_expected_metric_shape():
+    result = benchmark_payload(payload(), "invoice")
+    assert result.payload_name == "invoice"
+    assert result.json_bytes > 0
+    assert result.toon_bytes > 0
+    assert result.json_token_estimate > 0
+    assert result.conversion_ms >= 0
+
+
+def test_benchmark_payloads_returns_totals():
+    report = benchmark_payloads({"invoice": payload()})
+    assert len(report["results"]) == 1
+    assert report["totals"]["json_bytes"] >= report["results"][0]["json_bytes"]
+
+
+def test_load_and_write_benchmark_report(tmp_path: Path):
+    sample_path = tmp_path / "sample.json"
+    sample_path.write_text(canonical_json(payload()), encoding="utf-8")
+    loaded = load_json_payloads(tmp_path)
+    assert loaded["sample"]["entity"] == "invoice"
+
+    output = tmp_path / "report.json"
+    write_benchmark_report(benchmark_payloads(loaded), output)
+    assert output.exists()
+    assert "json_bytes" in output.read_text(encoding="utf-8")

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -36,8 +36,15 @@ def test_toon_conversion_returns_inspectable_compact_string():
     toon = json_to_toon(sample_payload())
     assert isinstance(toon, str)
     assert "entity:" in toon
-    assert "data.customer.name:" in toon
+    assert "customer:" in toon
+    assert "name: Alice" in toon
     assert len(toon) < len(str(sample_payload())) * 2
+
+
+def test_toon_conversion_uses_table_shape_for_repeated_objects():
+    toon = json_to_toon({"messages": [{"sender": "a", "text": "hello"}, {"sender": "b", "text": "hi"}]})
+    assert "messages[2]{sender,text}:" in toon
+    assert "a,hello" in toon
 
 
 def test_flatten_query_fields_extracts_nested_paths():

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1,6 +1,6 @@
 from toonflow.converter import flatten_query_fields, json_to_toon
 from toonflow.models import IngestRecord
-from toonflow.storage import SCHEMA_SQL, build_export_payload, build_insert_statement
+from toonflow.storage import SCHEMA_SQL, build_export_payload, build_field_rows, build_insert_statement
 from toonflow.validator import validate_payload
 
 
@@ -30,6 +30,14 @@ def test_validation_rejects_missing_required_keys():
     assert result.ok is False
     assert any("timestamp" in err for err in result.errors)
     assert any("data" in err for err in result.errors)
+
+
+def test_validation_rejects_bad_timestamp_and_id_type():
+    payload = sample_payload() | {"id": 123, "timestamp": "not-a-date"}
+    result = validate_payload(payload)
+    assert result.ok is False
+    assert any("timestamp" in err for err in result.errors)
+    assert any("id" in err for err in result.errors)
 
 
 def test_toon_conversion_returns_inspectable_compact_string():
@@ -72,7 +80,26 @@ def test_storage_helpers_prepare_sql_and_export_payload():
     assert exported["json"]["entity"] == "invoice"
 
 
+def test_storage_builds_relational_field_rows_for_queryable_values():
+    payload = sample_payload()
+    record = IngestRecord(
+        payload_id="demo-001",
+        source="demo-ui",
+        original_json=payload,
+        toon_payload=json_to_toon(payload),
+        extracted_fields=flatten_query_fields(payload),
+        status="validated",
+    )
+    rows = build_field_rows(record)
+    amount = next(row for row in rows if row["field_path"] == "data.amount")
+    assert amount["value_number"] == 245.5
+    customer = next(row for row in rows if row["field_path"] == "data.customer.name")
+    assert customer["value_string"] == "Alice"
+
+
 def test_schema_contains_dual_storage_columns():
     assert "toon_payload" in SCHEMA_SQL
     assert "extracted_fields" in SCHEMA_SQL
     assert "original_json" in SCHEMA_SQL
+    assert "toon_record_fields" in SCHEMA_SQL
+    assert "field_path" in SCHEMA_SQL

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -6,7 +6,9 @@ from toonflow.storage import (
     build_export_payload,
     build_field_rows,
     build_insert_statement,
+    create_schema,
     schema_statements,
+    store_record,
 )
 from toonflow.validator import validate_payload
 
@@ -23,6 +25,39 @@ def sample_payload():
             "tags": ["priority", "renewal"],
         },
     }
+
+
+class FakeCursor:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=None):
+        if self.connection.fail_on_execute:
+            raise RuntimeError("simulated storage failure")
+        self.connection.executed.append((sql, params))
+
+
+class FakeConnection:
+    def __init__(self):
+        self.executed = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.fail_on_execute = False
+
+    def cursor(self):
+        return FakeCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
 
 
 def test_validation_accepts_expected_payload():
@@ -152,6 +187,41 @@ def test_storage_builds_relational_field_rows_for_queryable_values():
     assert amount["value_number"] == 245.5
     customer = next(row for row in rows if row["field_path"] == "data.customer.name")
     assert customer["value_string"] == "Alice"
+
+
+def test_storage_helpers_create_schema_and_store_record_transactionally():
+    payload = sample_payload()
+    record = IngestRecord(
+        payload_id="demo-001",
+        source="demo-ui",
+        original_json=payload,
+        toon_payload=json_to_toon(payload),
+        extracted_fields=flatten_query_fields(payload),
+        status="validated",
+    )
+    conn = FakeConnection()
+    create_schema(conn)
+    assert conn.commits == 1
+    assert any("toon_record_fields" in sql for sql, _ in conn.executed)
+
+    store_record(conn, record)
+    assert conn.commits == 2
+    assert any("INSERT INTO toon_records" in sql for sql, _ in conn.executed)
+    assert any("DELETE FROM toon_record_fields" in sql for sql, _ in conn.executed)
+    assert any("INSERT INTO toon_record_fields" in sql for sql, _ in conn.executed)
+
+
+def test_storage_helpers_roll_back_on_failure():
+    conn = FakeConnection()
+    conn.fail_on_execute = True
+    try:
+        create_schema(conn)
+    except RuntimeError as exc:
+        assert "simulated storage failure" in str(exc)
+    else:
+        raise AssertionError("Expected simulated storage failure")
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
 
 
 def test_schema_contains_dual_storage_columns():

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -6,6 +6,7 @@ from toonflow.storage import (
     build_export_payload,
     build_field_rows,
     build_insert_statement,
+    schema_statements,
 )
 from toonflow.validator import validate_payload
 
@@ -44,6 +45,21 @@ def test_validation_rejects_bad_timestamp_and_id_type():
     assert result.ok is False
     assert any("timestamp" in err for err in result.errors)
     assert any("id" in err for err in result.errors)
+
+
+def test_validation_rejects_non_strict_json_values():
+    payload = sample_payload() | {"data": {"amount": float("nan")}}
+    result = validate_payload(payload)
+    assert result.ok is False
+    assert any("strict JSON" in err for err in result.errors)
+
+
+def test_validation_rejects_extracted_field_paths_that_exceed_schema_limit():
+    very_long_key = "x" * 260
+    payload = sample_payload() | {"data": {very_long_key: "value"}}
+    result = validate_payload(payload)
+    assert result.ok is False
+    assert any("field path exceeds" in err for err in result.errors)
 
 
 def test_toon_conversion_returns_inspectable_compact_string():
@@ -129,3 +145,7 @@ def test_schema_contains_dual_storage_columns():
     assert "original_json" in SCHEMA_SQL
     assert "toon_record_fields" in SCHEMA_SQL
     assert "field_path" in SCHEMA_SQL
+    statements = schema_statements()
+    assert len(statements) == 2
+    assert statements[0].startswith("CREATE TABLE IF NOT EXISTS toon_records")
+    assert statements[1].startswith("CREATE TABLE IF NOT EXISTS toon_record_fields")

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1,0 +1,71 @@
+from toonflow.converter import flatten_query_fields, json_to_toon
+from toonflow.models import IngestRecord
+from toonflow.storage import SCHEMA_SQL, build_export_payload, build_insert_statement
+from toonflow.validator import validate_payload
+
+
+def sample_payload():
+    return {
+        "id": "demo-001",
+        "entity": "invoice",
+        "timestamp": "2026-04-23T12:00:00Z",
+        "data": {
+            "customer": {"name": "Alice", "tier": "gold"},
+            "amount": 245.50,
+            "currency": "MYR",
+            "tags": ["priority", "renewal"],
+        },
+    }
+
+
+def test_validation_accepts_expected_payload():
+    result = validate_payload(sample_payload())
+    assert result.ok is True
+    assert result.errors == []
+    assert result.record_count == 1
+
+
+def test_validation_rejects_missing_required_keys():
+    result = validate_payload({"entity": "invoice"})
+    assert result.ok is False
+    assert any("timestamp" in err for err in result.errors)
+    assert any("data" in err for err in result.errors)
+
+
+def test_toon_conversion_returns_inspectable_compact_string():
+    toon = json_to_toon(sample_payload())
+    assert isinstance(toon, str)
+    assert "entity:" in toon
+    assert "data.customer.name:" in toon
+    assert len(toon) < len(str(sample_payload())) * 2
+
+
+def test_flatten_query_fields_extracts_nested_paths():
+    fields = flatten_query_fields(sample_payload())
+    assert fields["entity"] == "invoice"
+    assert fields["data.customer.name"] == "Alice"
+    assert fields["data.tags.__len__"] == 2
+
+
+def test_storage_helpers_prepare_sql_and_export_payload():
+    payload = sample_payload()
+    record = IngestRecord(
+        payload_id="demo-001",
+        source="demo-ui",
+        original_json=payload,
+        toon_payload=json_to_toon(payload),
+        extracted_fields=flatten_query_fields(payload),
+        status="validated",
+    )
+    sql, params = build_insert_statement(record)
+    assert "INSERT INTO toon_records" in sql
+    assert len(params) == 9
+    exported = build_export_payload(record)
+    assert exported["payload_id"] == "demo-001"
+    assert exported["json"]["entity"] == "invoice"
+
+
+def test_schema_contains_dual_storage_columns():
+    assert "toon_payload" in SCHEMA_SQL
+    assert "extracted_fields" in SCHEMA_SQL
+    assert "original_json" in SCHEMA_SQL

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -77,6 +77,13 @@ def test_toon_conversion_uses_table_shape_for_repeated_objects():
     assert "a,hello" in toon
 
 
+def test_toon_conversion_embeds_nested_lists_as_json_not_python_repr():
+    toon = json_to_toon({"matrix": [[1, 2], ["a", "b"]]})
+    assert "- [1,2]" in toon
+    assert '- ["a","b"]' in toon
+    assert "['a', 'b']" not in toon
+
+
 def test_flatten_query_fields_extracts_nested_paths():
     fields = flatten_query_fields(sample_payload())
     assert fields["entity"] == "invoice"
@@ -97,6 +104,14 @@ def test_flatten_query_fields_extracts_indexed_list_object_paths():
     assert fields["data.messages.__len__"] == 2
     assert fields["data.messages[0].sender"] == "customer"
     assert fields["data.messages[1].text"] == "Checking line items"
+
+
+def test_flatten_query_fields_extracts_nested_list_scalars():
+    fields = flatten_query_fields({"data": {"matrix": [[1, 2], [3, 4]]}})
+    assert fields["data.matrix.__len__"] == 2
+    assert fields["data.matrix[0].__len__"] == 2
+    assert fields["data.matrix[0][1]"] == 2
+    assert fields["data.matrix[1][0]"] == 3
 
 
 def test_storage_helpers_prepare_sql_and_export_payload():

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -82,6 +82,13 @@ def test_validation_rejects_bad_timestamp_and_id_type():
     assert any("id" in err for err in result.errors)
 
 
+def test_validation_rejects_payload_id_that_exceeds_storage_limit():
+    payload = sample_payload() | {"id": "x" * 129}
+    result = validate_payload(payload)
+    assert result.ok is False
+    assert any("128 characters" in err for err in result.errors)
+
+
 def test_validation_rejects_non_strict_json_values():
     payload = sample_payload() | {"data": {"amount": float("nan")}}
     result = validate_payload(payload)
@@ -170,6 +177,23 @@ def test_storage_helpers_prepare_sql_and_export_payload():
     delete_sql, delete_params = build_delete_fields_statement(record.payload_id)
     assert delete_sql == "DELETE FROM toon_record_fields WHERE payload_id = %s"
     assert delete_params == ("demo-001",)
+
+
+def test_storage_uses_strict_json_serialisation():
+    record = IngestRecord(
+        payload_id="bad-json",
+        source="test",
+        original_json={"value": float("nan")},
+        toon_payload="",
+        extracted_fields={},
+        status="rejected",
+    )
+    try:
+        build_insert_statement(record)
+    except ValueError as exc:
+        assert "JSON" in str(exc) or "range" in str(exc)
+    else:
+        raise AssertionError("Expected strict JSON serialisation failure")
 
 
 def test_storage_builds_relational_field_rows_for_queryable_values():

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1,6 +1,12 @@
 from toonflow.converter import flatten_query_fields, json_to_toon
 from toonflow.models import IngestRecord
-from toonflow.storage import SCHEMA_SQL, build_export_payload, build_field_rows, build_insert_statement
+from toonflow.storage import (
+    SCHEMA_SQL,
+    build_delete_fields_statement,
+    build_export_payload,
+    build_field_rows,
+    build_insert_statement,
+)
 from toonflow.validator import validate_payload
 
 
@@ -62,6 +68,21 @@ def test_flatten_query_fields_extracts_nested_paths():
     assert fields["data.tags.__len__"] == 2
 
 
+def test_flatten_query_fields_extracts_indexed_list_object_paths():
+    payload = sample_payload() | {
+        "data": {
+            "messages": [
+                {"sender": "customer", "text": "Need invoice help"},
+                {"sender": "agent", "text": "Checking line items"},
+            ]
+        }
+    }
+    fields = flatten_query_fields(payload)
+    assert fields["data.messages.__len__"] == 2
+    assert fields["data.messages[0].sender"] == "customer"
+    assert fields["data.messages[1].text"] == "Checking line items"
+
+
 def test_storage_helpers_prepare_sql_and_export_payload():
     payload = sample_payload()
     record = IngestRecord(
@@ -74,10 +95,15 @@ def test_storage_helpers_prepare_sql_and_export_payload():
     )
     sql, params = build_insert_statement(record)
     assert "INSERT INTO toon_records" in sql
+    assert "ON DUPLICATE KEY UPDATE" in sql
     assert len(params) == 9
     exported = build_export_payload(record)
     assert exported["payload_id"] == "demo-001"
     assert exported["json"]["entity"] == "invoice"
+
+    delete_sql, delete_params = build_delete_fields_statement(record.payload_id)
+    assert delete_sql == "DELETE FROM toon_record_fields WHERE payload_id = %s"
+    assert delete_params == ("demo-001",)
 
 
 def test_storage_builds_relational_field_rows_for_queryable_values():

--- a/tests/test_core_pipeline_script.py
+++ b/tests/test_core_pipeline_script.py
@@ -1,0 +1,29 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_core_pipeline_script_can_include_invalid_samples(tmp_path: Path):
+    output = tmp_path / "pipeline.json"
+    command = [
+        sys.executable,
+        str(ROOT / "scripts" / "run_core_pipeline.py"),
+        "--samples",
+        str(ROOT / "data" / "samples"),
+        "--invalid-samples",
+        str(ROOT / "data" / "invalid_samples"),
+        "--output",
+        str(output),
+    ]
+    completed = subprocess.run(command, cwd=ROOT, env={"PYTHONPATH": str(ROOT / "src")}, check=True, capture_output=True, text=True)
+    assert "Rejected: 2" in completed.stdout
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["accepted"] == 2
+    assert report["rejected"] == 2
+    rejected = [record for record in report["records"] if record["status"] == "rejected"]
+    assert len(rejected) == 2
+    assert all(record["validation_errors"] for record in rejected)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,39 @@
+import sys
+
+import pytest
+
+from toonflow.db import MariaDBConfig, connect_mariadb, load_mariadb_config
+
+
+def env():
+    return {
+        "TOONFLOW_DB_HOST": "localhost",
+        "TOONFLOW_DB_PORT": "3307",
+        "TOONFLOW_DB_USER": "toonflow",
+        "TOONFLOW_DB_PASSWORD": "example-password",
+        "TOONFLOW_DB_NAME": "toonflow_test",
+    }
+
+
+def test_load_mariadb_config_from_env_mapping():
+    config = load_mariadb_config(env())
+    assert config.host == "localhost"
+    assert config.port == 3307
+    assert config.user == "toonflow"
+    assert config.database == "toonflow_test"
+
+
+def test_load_mariadb_config_reports_missing_values():
+    with pytest.raises(ValueError, match="TOONFLOW_DB_PASSWORD"):
+        load_mariadb_config({"TOONFLOW_DB_HOST": "localhost", "TOONFLOW_DB_USER": "toonflow", "TOONFLOW_DB_NAME": "db"})
+
+
+def test_config_redacts_password():
+    config = MariaDBConfig(host="h", port=3306, user="u", password="p", database="d")
+    assert config.redacted()["password"] == "***"
+
+
+def test_connect_mariadb_gives_actionable_error_when_connector_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mariadb", None)
+    with pytest.raises(RuntimeError, match="MariaDB connector is not installed"):
+        connect_mariadb(MariaDBConfig(host="h", port=3306, user="u", password="p", database="d"))

--- a/tests/test_end_to_end_core_pipeline.py
+++ b/tests/test_end_to_end_core_pipeline.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from toonflow.converter import flatten_query_fields, json_to_toon
+from toonflow.repository import InMemoryRecordStore
+from toonflow.service import batch_ingest_and_store_payloads, ingest_and_store_payload
+from toonflow.storage import SCHEMA_SQL, build_field_rows
+
+
+def payload():
+    return {
+        "id": "core-e2e-001",
+        "entity": "invoice",
+        "timestamp": "2026-04-24T10:00:00Z",
+        "data": {
+            "customer": {"name": "Alice"},
+            "amount": 245.5,
+            "approved": True,
+            "items": [
+                {"sku": "A-1", "qty": 2},
+                {"sku": "B-2", "qty": 1},
+            ],
+        },
+    }
+
+
+def test_valid_payload_runs_validate_convert_extract_store_path():
+    store = InMemoryRecordStore()
+    result = ingest_and_store_payload(payload(), store, source="core-test")
+
+    stored = store.get("core-e2e-001")
+    assert stored is not None
+    assert result["status"] == "validated"
+    assert stored.original_json["entity"] == "invoice"
+    assert stored.toon_payload == json_to_toon(payload())
+    assert stored.extracted_fields == flatten_query_fields(payload())
+    assert stored.extracted_fields["data.items[0].sku"] == "A-1"
+
+    field_rows = build_field_rows(stored)
+    assert any(row["field_path"] == "data.amount" and row["value_number"] == 245.5 for row in field_rows)
+    assert any(row["field_path"] == "data.approved" and row["value_boolean"] is True for row in field_rows)
+
+
+def test_invalid_payload_is_rejected_but_still_auditable():
+    store = InMemoryRecordStore()
+    result = ingest_and_store_payload({"entity": "invoice"}, store, source="core-test", payload_id="bad-e2e-001")
+
+    stored = store.get("bad-e2e-001")
+    assert stored is not None
+    assert result["status"] == "rejected"
+    assert stored.validation_errors
+    assert stored.toon_payload == ""
+    assert stored.extracted_fields == {}
+
+
+def test_batch_pipeline_preserves_mixed_statuses():
+    store = InMemoryRecordStore()
+    result = batch_ingest_and_store_payloads([payload(), {"entity": "invoice"}], store, source="core-batch")
+
+    assert result["total"] == 2
+    assert result["accepted"] == 1
+    assert result["rejected"] == 1
+    assert len(store.list()) == 2
+
+
+def test_schema_file_matches_runtime_schema_constant():
+    schema_file = Path(__file__).resolve().parents[1] / "src" / "toonflow" / "schema.sql"
+    assert schema_file.read_text(encoding="utf-8").strip() == SCHEMA_SQL

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,26 @@
+from toonflow.evaluator import evaluate_payload
+
+
+def valid_payload():
+    return {
+        "id": "eval-001",
+        "entity": "invoice",
+        "timestamp": "2026-04-23T12:00:00Z",
+        "data": {"customer": {"name": "Alice"}, "amount": 245.50},
+    }
+
+
+def test_evaluate_payload_returns_demo_ready_response():
+    result = evaluate_payload(valid_payload(), payload_name="invoice")
+    assert result["status"] == "ready"
+    assert result["validation"]["ok"] is True
+    assert result["toon_payload"]
+    assert result["extracted_fields"]["data.customer.name"] == "Alice"
+    assert result["metrics"]["payload_name"] == "invoice"
+
+
+def test_evaluate_payload_rejects_invalid_json_contract():
+    result = evaluate_payload({"entity": "invoice"})
+    assert result["status"] == "rejected"
+    assert result["metrics"] is None
+    assert result["validation"]["errors"]

--- a/tests/test_mariadb_live_optional.py
+++ b/tests/test_mariadb_live_optional.py
@@ -1,0 +1,46 @@
+import os
+
+import pytest
+
+from toonflow.converter import flatten_query_fields, json_to_toon
+from toonflow.db import connect_mariadb, load_mariadb_config
+from toonflow.mariadb_repository import MariaDBRecordRepository
+from toonflow.models import IngestRecord
+
+
+REQUIRED_ENV = ("TOONFLOW_DB_HOST", "TOONFLOW_DB_USER", "TOONFLOW_DB_PASSWORD", "TOONFLOW_DB_NAME")
+
+
+def live_db_available() -> bool:
+    return all(os.environ.get(name) for name in REQUIRED_ENV)
+
+
+@pytest.mark.skipif(not live_db_available(), reason="live MariaDB environment variables are not configured")
+def test_live_mariadb_core_ingestion_path():
+    payload = {
+        "id": "live-test-001",
+        "entity": "invoice",
+        "timestamp": "2026-04-24T10:00:00Z",
+        "data": {"customer": {"name": "Alice"}, "amount": 245.5},
+    }
+    record = IngestRecord(
+        payload_id=payload["id"],
+        source="live-test",
+        original_json=payload,
+        toon_payload=json_to_toon(payload),
+        extracted_fields=flatten_query_fields(payload),
+        status="validated",
+    )
+
+    connection = connect_mariadb(load_mariadb_config())
+    repo = MariaDBRecordRepository(connection)
+    repo.create_schema()
+    repo.save(record)
+
+    stored = repo.get("live-test-001")
+    assert stored is not None
+    assert stored["status"] == "validated"
+    assert stored["extracted_fields"]["data.customer.name"] == "Alice"
+
+    matches = repo.find_by_field("entity", "invoice")
+    assert any(item["payload_id"] == "live-test-001" for item in matches)

--- a/tests/test_mariadb_repository.py
+++ b/tests/test_mariadb_repository.py
@@ -63,6 +63,7 @@ def test_create_schema_executes_schema_and_commits():
     repo = MariaDBRecordRepository(conn)
     repo.create_schema()
     assert 'CREATE TABLE IF NOT EXISTS toon_records' in conn.executed[0][0]
+    assert any('CREATE TABLE IF NOT EXISTS toon_record_fields' in sql for sql, _ in conn.executed)
     assert conn.commits == 1
 
 
@@ -73,6 +74,7 @@ def test_save_executes_insert_and_commits():
     sql, params = conn.executed[0]
     assert 'INSERT INTO toon_records' in sql
     assert params[0] == 'demo-001'
+    assert any('INSERT INTO toon_record_fields' in sql for sql, _ in conn.executed)
     assert conn.commits == 1
 
 

--- a/tests/test_mariadb_repository.py
+++ b/tests/test_mariadb_repository.py
@@ -73,9 +73,34 @@ def test_save_executes_insert_and_commits():
     repo.save(sample_record())
     sql, params = conn.executed[0]
     assert 'INSERT INTO toon_records' in sql
+    assert 'ON DUPLICATE KEY UPDATE' in sql
     assert params[0] == 'demo-001'
+    assert any('DELETE FROM toon_record_fields' in sql for sql, _ in conn.executed)
     assert any('INSERT INTO toon_record_fields' in sql for sql, _ in conn.executed)
     assert conn.commits == 1
+
+
+def test_find_by_field_queries_relational_field_table():
+    conn = FakeConnection()
+    conn.fetchall_result = [
+        (
+            'demo-001',
+            'test',
+            '{"entity":"invoice"}',
+            'entity: invoice',
+            '{"entity":"invoice"}',
+            'validated',
+            '[]',
+            '[]',
+            '2026-04-23 12:00:00',
+        )
+    ]
+    repo = MariaDBRecordRepository(conn)
+    result = repo.find_by_field('entity', 'invoice')
+    sql, params = conn.executed[0]
+    assert 'JOIN toon_record_fields' in sql
+    assert params[0] == 'entity'
+    assert result[0]['payload_id'] == 'demo-001'
 
 
 def test_get_maps_row_to_dict():

--- a/tests/test_mariadb_repository.py
+++ b/tests/test_mariadb_repository.py
@@ -16,6 +16,8 @@ class FakeCursor:
         return False
 
     def execute(self, sql, params=None):
+        if self.connection.fail_on_execute:
+            raise RuntimeError('simulated database failure')
         self.last_sql = sql
         self.last_params = params
         self.connection.executed.append((sql, params))
@@ -31,6 +33,8 @@ class FakeConnection:
     def __init__(self):
         self.executed = []
         self.commits = 0
+        self.rollbacks = 0
+        self.fail_on_execute = False
         self.fetchone_result = None
         self.fetchall_result = []
 
@@ -39,6 +43,9 @@ class FakeConnection:
 
     def commit(self):
         self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
 
 
 def sample_record():
@@ -78,6 +85,21 @@ def test_save_executes_insert_and_commits():
     assert any('DELETE FROM toon_record_fields' in sql for sql, _ in conn.executed)
     assert any('INSERT INTO toon_record_fields' in sql for sql, _ in conn.executed)
     assert conn.commits == 1
+    assert conn.rollbacks == 0
+
+
+def test_save_rolls_back_when_database_write_fails():
+    conn = FakeConnection()
+    conn.fail_on_execute = True
+    repo = MariaDBRecordRepository(conn)
+    try:
+        repo.save(sample_record())
+    except RuntimeError as exc:
+        assert 'simulated database failure' in str(exc)
+    else:
+        raise AssertionError('Expected simulated database failure')
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
 
 
 def test_find_by_field_queries_relational_field_table():

--- a/tests/test_mariadb_repository.py
+++ b/tests/test_mariadb_repository.py
@@ -1,0 +1,96 @@
+from toonflow.converter import flatten_query_fields, json_to_toon
+from toonflow.mariadb_repository import MariaDBRecordRepository
+from toonflow.models import IngestRecord
+
+
+class FakeCursor:
+    def __init__(self, connection):
+        self.connection = connection
+        self.last_sql = None
+        self.last_params = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=None):
+        self.last_sql = sql
+        self.last_params = params
+        self.connection.executed.append((sql, params))
+
+    def fetchone(self):
+        return self.connection.fetchone_result
+
+    def fetchall(self):
+        return self.connection.fetchall_result
+
+
+class FakeConnection:
+    def __init__(self):
+        self.executed = []
+        self.commits = 0
+        self.fetchone_result = None
+        self.fetchall_result = []
+
+    def cursor(self):
+        return FakeCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+
+def sample_record():
+    payload = {
+        'id': 'demo-001',
+        'entity': 'invoice',
+        'timestamp': '2026-04-23T12:00:00Z',
+        'data': {'amount': 245.5},
+    }
+    return IngestRecord(
+        payload_id='demo-001',
+        source='test',
+        original_json=payload,
+        toon_payload=json_to_toon(payload),
+        extracted_fields=flatten_query_fields(payload),
+        status='validated',
+    )
+
+
+def test_create_schema_executes_schema_and_commits():
+    conn = FakeConnection()
+    repo = MariaDBRecordRepository(conn)
+    repo.create_schema()
+    assert 'CREATE TABLE IF NOT EXISTS toon_records' in conn.executed[0][0]
+    assert conn.commits == 1
+
+
+def test_save_executes_insert_and_commits():
+    conn = FakeConnection()
+    repo = MariaDBRecordRepository(conn)
+    repo.save(sample_record())
+    sql, params = conn.executed[0]
+    assert 'INSERT INTO toon_records' in sql
+    assert params[0] == 'demo-001'
+    assert conn.commits == 1
+
+
+def test_get_maps_row_to_dict():
+    conn = FakeConnection()
+    conn.fetchone_result = (
+        'demo-001',
+        'test',
+        '{"entity":"invoice"}',
+        'entity: "invoice"',
+        '{"entity":"invoice"}',
+        'validated',
+        '[]',
+        '[]',
+        '2026-04-23 12:00:00',
+    )
+    repo = MariaDBRecordRepository(conn)
+    result = repo.get('demo-001')
+    assert result['payload_id'] == 'demo-001'
+    assert result['json']['entity'] == 'invoice'
+    assert result['status'] == 'validated'

--- a/tests/test_mariadb_repository.py
+++ b/tests/test_mariadb_repository.py
@@ -125,6 +125,15 @@ def test_find_by_field_queries_relational_field_table():
     assert result[0]['payload_id'] == 'demo-001'
 
 
+def test_find_by_field_can_query_null_relational_values():
+    conn = FakeConnection()
+    repo = MariaDBRecordRepository(conn)
+    repo.find_by_field('data.optional', None)
+    sql, params = conn.executed[0]
+    assert 'IS NULL' in sql
+    assert params == ('data.optional', None, None, None, True)
+
+
 def test_get_maps_row_to_dict():
     conn = FakeConnection()
     conn.fetchone_result = (

--- a/tests/test_mariadb_repository.py
+++ b/tests/test_mariadb_repository.py
@@ -82,7 +82,7 @@ def test_get_maps_row_to_dict():
         'demo-001',
         'test',
         '{"entity":"invoice"}',
-        'entity: "invoice"',
+        'entity: invoice',
         '{"entity":"invoice"}',
         'validated',
         '[]',

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,46 @@
+import pytest
+
+from toonflow.models import IngestRecord
+from toonflow.query import build_sql_preview, field_matches, hybrid_query_response, query_records
+
+
+def record(payload_id='r1', amount=245.5):
+    return IngestRecord(
+        payload_id=payload_id,
+        source='test',
+        original_json={},
+        toon_payload='entity: invoice',
+        extracted_fields={'entity': 'invoice', 'data.amount': amount},
+        status='validated',
+    )
+
+
+def test_field_matches_supported_operators():
+    assert field_matches('invoice', 'invoice') is True
+    assert field_matches('priority billing', 'billing', 'contains') is True
+    assert field_matches(10, 5, 'gt') is True
+    assert field_matches(10, 10, 'gte') is True
+    assert field_matches(5, 10, 'lt') is True
+    assert field_matches(5, 5, 'lte') is True
+
+
+def test_query_records_filters_extracted_fields():
+    matches = query_records([record('a', 100), record('b', 300)], 'data.amount', 200, 'gt')
+    assert [item.payload_id for item in matches] == ['b']
+
+
+def test_build_sql_preview_describes_mariadb_json_field_lookup():
+    preview = build_sql_preview('data.amount', 'gte')
+    assert 'JSON_EXTRACT(extracted_fields' in preview['sql']
+    assert preview['params'][0] == '$."data.amount"'
+
+
+def test_hybrid_query_response_returns_toon_payloads():
+    response = hybrid_query_response([record()], 'entity', 'invoice')
+    assert response['matched_count'] == 1
+    assert response['records'][0]['toon_payload'] == 'entity: invoice'
+
+
+def test_invalid_operator_raises():
+    with pytest.raises(ValueError):
+        field_matches('a', 'a', 'bad')

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,25 @@
+from toonflow.service import build_ingest_record, ingest_payload
+from toonflow.models import IngestRequest
+
+
+def valid_payload():
+    return {
+        'entity': 'invoice',
+        'timestamp': '2026-04-23T12:00:00Z',
+        'data': {'customer': {'name': 'Alice'}, 'amount': 245.50},
+    }
+
+
+def test_build_ingest_record_valid_payload():
+    request = IngestRequest(source='test', payload=valid_payload())
+    record = build_ingest_record(request)
+    assert record.status == 'validated'
+    assert record.toon_payload
+    assert record.extracted_fields['data.customer.name'] == 'Alice'
+
+
+def test_ingest_payload_rejected_on_invalid_payload():
+    result = ingest_payload({'entity': 'invoice'}, source='test')
+    assert result['status'] == 'rejected'
+    assert result['toon_payload'] == ''
+    assert result['validation_errors']

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -34,6 +34,13 @@ def test_ingest_payload_rejected_on_invalid_payload():
     assert result['validation_errors']
 
 
+def test_ingest_payload_rejects_non_object_without_crashing():
+    result = ingest_payload(['not', 'object'], source='test', payload_id='bad-list')
+    assert result['payload_id'] == 'bad-list'
+    assert result['status'] == 'rejected'
+    assert result['validation_errors'] == ['Payload must be a JSON object']
+
+
 def test_invalid_payload_id_type_is_not_used_as_storage_id():
     request = IngestRequest(source='test', payload=valid_payload() | {'id': 123})
     record = build_ingest_record(request)
@@ -50,6 +57,16 @@ def test_ingest_and_store_rejects_non_object_json_without_crashing():
     assert stored is not None
     assert stored.original_json == ['not', 'an', 'object']
     assert stored.validation_errors == ['Payload must be a JSON object']
+
+
+def test_rejected_non_serialisable_payload_keeps_auditable_json_safe_repr():
+    store = InMemoryRecordStore()
+    result = ingest_and_store_payload({'entity': 'invoice', 'bad': {1, 2}}, store, source='test', payload_id='bad-set')
+    stored = store.get('bad-set')
+    assert result['status'] == 'rejected'
+    assert stored is not None
+    assert stored.original_json['_audit_note'].startswith('Payload was not strict JSON serialisable')
+    assert 'bad' in stored.original_json['raw_repr']
 
 
 def test_validate_and_convert_helpers():

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,5 +1,14 @@
-from toonflow.service import batch_ingest_payloads, build_ingest_record, convert_only, ingest_payload, validate_only
+from toonflow.service import (
+    batch_ingest_and_store_payloads,
+    batch_ingest_payloads,
+    build_ingest_record,
+    convert_only,
+    ingest_and_store_payload,
+    ingest_payload,
+    validate_only,
+)
 from toonflow.models import IngestRequest
+from toonflow.repository import InMemoryRecordStore
 
 
 def valid_payload():
@@ -38,3 +47,32 @@ def test_batch_ingest_summarises_accepted_and_rejected():
     assert result['total'] == 2
     assert result['accepted'] == 1
     assert result['rejected'] == 1
+
+
+def test_ingest_and_store_payload_persists_valid_record_end_to_end():
+    store = InMemoryRecordStore()
+    result = ingest_and_store_payload(valid_payload(), store, source='test', payload_id='stored-001')
+    assert result['status'] == 'validated'
+    assert result['stored'] is True
+    stored = store.get('stored-001')
+    assert stored is not None
+    assert stored.toon_payload
+    assert stored.extracted_fields['data.customer.name'] == 'Alice'
+
+
+def test_ingest_and_store_payload_persists_rejected_record_with_errors():
+    store = InMemoryRecordStore()
+    result = ingest_and_store_payload({'entity': 'invoice'}, store, source='test', payload_id='bad-001')
+    assert result['status'] == 'rejected'
+    stored = store.get('bad-001')
+    assert stored is not None
+    assert stored.validation_errors
+    assert stored.toon_payload == ''
+
+
+def test_batch_ingest_and_store_payloads_persists_all_statuses():
+    store = InMemoryRecordStore()
+    result = batch_ingest_and_store_payloads([valid_payload(), {'entity': 'invoice'}], store, source='test')
+    assert result['total'] == 2
+    assert result['stored'] == 2
+    assert len(store.list()) == 2

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,4 +1,4 @@
-from toonflow.service import build_ingest_record, ingest_payload
+from toonflow.service import batch_ingest_payloads, build_ingest_record, convert_only, ingest_payload, validate_only
 from toonflow.models import IngestRequest
 
 
@@ -23,3 +23,18 @@ def test_ingest_payload_rejected_on_invalid_payload():
     assert result['status'] == 'rejected'
     assert result['toon_payload'] == ''
     assert result['validation_errors']
+
+
+def test_validate_and_convert_helpers():
+    validation = validate_only(valid_payload())
+    assert validation['ok'] is True
+    conversion = convert_only(valid_payload())
+    assert conversion['status'] == 'converted'
+    assert conversion['toon_payload']
+
+
+def test_batch_ingest_summarises_accepted_and_rejected():
+    result = batch_ingest_payloads([valid_payload(), {'entity': 'invoice'}], source='test')
+    assert result['total'] == 2
+    assert result['accepted'] == 1
+    assert result['rejected'] == 1

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -34,6 +34,24 @@ def test_ingest_payload_rejected_on_invalid_payload():
     assert result['validation_errors']
 
 
+def test_invalid_payload_id_type_is_not_used_as_storage_id():
+    request = IngestRequest(source='test', payload=valid_payload() | {'id': 123})
+    record = build_ingest_record(request)
+    assert record.status == 'rejected'
+    assert isinstance(record.payload_id, str)
+    assert record.payload_id != '123'
+
+
+def test_ingest_and_store_rejects_non_object_json_without_crashing():
+    store = InMemoryRecordStore()
+    result = ingest_and_store_payload(['not', 'an', 'object'], store, source='test', payload_id='bad-list')
+    stored = store.get('bad-list')
+    assert result['status'] == 'rejected'
+    assert stored is not None
+    assert stored.original_json == ['not', 'an', 'object']
+    assert stored.validation_errors == ['Payload must be a JSON object']
+
+
 def test_validate_and_convert_helpers():
     validation = validate_only(valid_payload())
     assert validation['ok'] is True

--- a/worklog/core_backend_notes.md
+++ b/worklog/core_backend_notes.md
@@ -1,0 +1,9 @@
+# Core backend notes
+
+First backend slice covers issues 3, 4, and 5:
+- JSON validation and ingest status
+- JSON to compact TOON-style conversion
+- extraction of SQL-friendly fields
+- MariaDB dual-storage schema
+- service/API skeleton around the ingest flow
+- tests for validation, conversion, extraction, storage helpers, and service behavior


### PR DESCRIPTION
## Summary
- add JSON validation for the first ingestion contract
- add compact JSON-to-TOON-style conversion
- extract SQL-friendly fields for dual storage
- add MariaDB schema draft and storage helpers
- add ingest service, in-memory repository, FastAPI endpoints, sample payload, and tests
- add batch ingest endpoint and API coverage

## Validation
- PYTHONPATH=src .venv/bin/python -m pytest tests -q
- 15 passed

## Notes
This is the first backend implementation slice for the validation, conversion, API, batch-ingest, and dual-storage milestone.