### PR TITLE
Complete batch benchmark demo and polish flow

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -79,3 +79,26 @@ Implemented endpoints:
 - `GET /records/{payload_id}/export`
 
 Export supports `?format=full`, `?format=json`, or `?format=toon`.
+
+
+## Run JSON vs TOON benchmark
+
+```bash
+PYTHONPATH=src python scripts/run_benchmark.py
+```
+
+## Run full verification
+
+```bash
+PYTHONPATH=src python scripts/verify_all.py
+```
+
+## Demo flow
+
+Run the API, then open `/demo`:
+
+```bash
+PYTHONPATH=src fastapi dev src/toonflow/api.py
+```
+
+The demo page supports pasted JSON evaluation, ingestion, hybrid extracted-field query, and TOON export through the API endpoints.

--- a/benchmarks/benchmark_protocol.md
+++ b/benchmarks/benchmark_protocol.md
@@ -1,0 +1,22 @@
+# JSON vs TOON benchmark protocol
+
+The benchmark compares each source payload in two transport formats:
+
+1. canonical compact JSON
+2. TOONFlow compact TOON-style output
+
+Metrics captured:
+- UTF-8 payload bytes
+- estimated token count using a repeatable local `len(text) / 4` heuristic
+- byte and token savings percentage
+- estimated API cost using a configurable cost-per-million-token assumption
+- conversion time in milliseconds
+- derived conversion throughput in records per second
+
+Token and cost values are estimates for repeatable local comparison, not pricing claims.
+
+Run locally:
+
+```bash
+PYTHONPATH=src python scripts/run_benchmark.py
+```

--- a/benchmarks/latest_report.md
+++ b/benchmarks/latest_report.md
@@ -1,0 +1,17 @@
+# JSON vs TOON Benchmark Results
+
+| Payload | JSON bytes | TOON bytes | Byte savings | Token savings | Conversion ms |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| demo_invoice | 184 | 168 | 8.7% | 8.7% | 0.0866 |
+| demo_support_ticket | 359 | 324 | 9.75% | 10.0% | 0.0597 |
+
+## Totals
+
+- JSON bytes: 543
+- TOON bytes: 492
+- Byte savings: 9.39%
+- Estimated token savings: 9.56%
+- Estimated cost savings: $1.95e-06
+- Conversion throughput: 13670.54 records/sec
+
+Token and cost values are estimates for repeatable local comparison.

--- a/benchmarks/latest_results.json
+++ b/benchmarks/latest_results.json
@@ -1,0 +1,51 @@
+{
+  "results": [
+    {
+      "payload_name": "demo_invoice",
+      "json_bytes": 184,
+      "toon_bytes": 168,
+      "byte_savings": 16,
+      "byte_savings_percent": 8.7,
+      "json_token_estimate": 46,
+      "toon_token_estimate": 42,
+      "token_savings": 4,
+      "token_savings_percent": 8.7,
+      "json_estimated_cost_usd": 6.9e-06,
+      "toon_estimated_cost_usd": 6.3e-06,
+      "estimated_cost_savings_usd": 6e-07,
+      "conversion_ms": 0.0866,
+      "records_per_second": 11551.34
+    },
+    {
+      "payload_name": "demo_support_ticket",
+      "json_bytes": 359,
+      "toon_bytes": 324,
+      "byte_savings": 35,
+      "byte_savings_percent": 9.75,
+      "json_token_estimate": 90,
+      "toon_token_estimate": 81,
+      "token_savings": 9,
+      "token_savings_percent": 10.0,
+      "json_estimated_cost_usd": 1.35e-05,
+      "toon_estimated_cost_usd": 1.215e-05,
+      "estimated_cost_savings_usd": 1.35e-06,
+      "conversion_ms": 0.0597,
+      "records_per_second": 16763.61
+    }
+  ],
+  "totals": {
+    "json_bytes": 543,
+    "toon_bytes": 492,
+    "json_token_estimate": 136,
+    "toon_token_estimate": 123,
+    "json_estimated_cost_usd": 2.04e-05,
+    "toon_estimated_cost_usd": 1.845e-05,
+    "conversion_ms": 0.1463,
+    "byte_savings": 51,
+    "byte_savings_percent": 9.39,
+    "token_savings": 13,
+    "token_savings_percent": 9.56,
+    "estimated_cost_savings_usd": 1.95e-06,
+    "records_per_second": 13670.54
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,3 +57,13 @@ The system should visibly support:
 - error logging
 - ingestion status tracking
 - batch processing
+
+
+## Demo and benchmark layer
+The final demo layer builds on the core API:
+
+- `/batch/ingest` stores mixed valid/invalid payload batches and reports partial failures
+- `/evaluate` validates, converts, extracts fields, and returns JSON vs TOON metrics without storing
+- `/query` filters stored records by extracted fields and returns TOON payloads for downstream AI context
+- `/demo` provides a lightweight evaluator page for paste/evaluate/ingest/query flow
+- benchmark scripts generate JSON and Markdown summaries for payload size, estimated tokens/cost, conversion latency, and throughput

--- a/docs/development-roadmap.md
+++ b/docs/development-roadmap.md
@@ -25,13 +25,19 @@ Status: implemented in PR #14. The API layer exposes health, validation, convers
 - Define benchmark protocol
 - Measure payload size, token count, estimated cost, conversion time, and ingestion throughput
 
+Status: implemented in PR #15. Batch ingest accepts mixed valid/invalid payloads and reports accepted/rejected/stored counts. Benchmark tooling writes JSON and Markdown reports for bytes, estimated tokens/cost, conversion time, and throughput.
+
 ## Phase 5 — Demo and polish (27–28 Apr)
 - Build simple interactive demo
 - Add one hybrid SQL + TOON workflow
 - Improve docs and setup instructions
+
+Status: implemented in PR #15. The `/demo` page and evaluator/query endpoints support pasted JSON evaluation, metrics, ingest, hybrid extracted-field query, and export.
 
 ## Phase 6 — Final validation (28 Apr)
 - Bug fixing
 - Demo rehearsal
 - Benchmark verification
 - Repo cleanup
+
+Status: implemented in PR #15. `scripts/verify_all.py` runs tests, core pipeline, and benchmark generation as the final readiness gate.

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from toonflow.benchmark import benchmark_payloads, load_json_payloads, write_benchmark_report, write_markdown_report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run JSON vs TOON benchmark over sample payloads.")
+    parser.add_argument("--samples", default=str(ROOT / "data" / "samples"), help="Directory of JSON samples")
+    parser.add_argument("--output", default=str(ROOT / "benchmarks" / "latest_results.json"))
+    parser.add_argument("--markdown-output", default=str(ROOT / "benchmarks" / "latest_report.md"))
+    args = parser.parse_args()
+
+    payloads = load_json_payloads(args.samples)
+    if not payloads:
+        raise SystemExit(f"No JSON sample payloads found in {args.samples}")
+
+    report = benchmark_payloads(payloads)
+    write_benchmark_report(report, args.output)
+    write_markdown_report(report, args.markdown_output)
+    totals = report["totals"]
+    print(f"Benchmarked {len(payloads)} payload(s)")
+    print(f"JSON bytes: {totals['json_bytes']}")
+    print(f"TOON bytes: {totals['toon_bytes']}")
+    print(f"Byte savings: {totals['byte_savings_percent']}%")
+    print(f"Estimated token savings: {totals['token_savings_percent']}%")
+    print(f"Estimated cost savings: ${totals['estimated_cost_savings_usd']}")
+    print(f"Conversion throughput: {totals['records_per_second']} records/sec")
+    print(f"Wrote {args.output}")
+    print(f"Wrote {args.markdown_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_all.py
+++ b/scripts/verify_all.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON = sys.executable
+
+
+COMMANDS = [
+    [PYTHON, "-m", "pytest", "tests", "-q"],
+    [PYTHON, "scripts/run_core_pipeline.py", "--invalid-samples", "data/invalid_samples"],
+    [PYTHON, "scripts/run_benchmark.py"],
+]
+
+
+def main() -> int:
+    for command in COMMANDS:
+        print(f"$ {' '.join(command)}")
+        subprocess.run(command, cwd=ROOT, env={"PYTHONPATH": str(ROOT / "src")}, check=True)
+    print("All verification checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/toonflow/api.py
+++ b/src/toonflow/api.py
@@ -4,18 +4,60 @@ from typing import Any
 
 try:
     from fastapi import Body, FastAPI, HTTPException
+    from fastapi.responses import HTMLResponse
 except ImportError:  # keeps the core package importable without API extras
     Body = None
     FastAPI = None
     HTTPException = Exception
+    HTMLResponse = None
 
+from .evaluator import evaluate_payload
 from .models import IngestRecord, IngestRequest
+from .query import hybrid_query_response
 from .repository import InMemoryRecordStore
-from .service import build_ingest_record, convert_only, export_record, summarize_record, validate_only
+from .service import build_batch_records, build_ingest_record, convert_only, export_record, summarize_record, validate_only
 
 
 store = InMemoryRecordStore()
 app = FastAPI(title="TOONFlow API") if FastAPI else None
+
+
+DEMO_HTML = """
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>TOONFlow Demo</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 1100px; margin: 2rem auto; padding: 0 1rem; }
+    textarea { width: 100%; min-height: 260px; font-family: ui-monospace, monospace; }
+    button { margin: 0.5rem 0.5rem 0.5rem 0; padding: 0.6rem 1rem; }
+    pre { background: #111827; color: #e5e7eb; padding: 1rem; overflow: auto; }
+  </style>
+</head>
+<body>
+  <h1>TOONFlow evaluator</h1>
+  <p>Paste JSON, validate it, convert/store it, compare metrics, query extracted fields, and export TOON.</p>
+  <textarea id="payload">{"id":"demo-ui-001","entity":"invoice","timestamp":"2026-04-24T10:00:00Z","data":{"customer":{"name":"Alice"},"amount":245.5}}</textarea>
+  <br />
+  <button onclick="send('/evaluate')">Evaluate</button>
+  <button onclick="send('/ingest')">Ingest</button>
+  <button onclick="queryDemo()">Query entity=invoice</button>
+  <pre id="output">Ready.</pre>
+  <script>
+    async function send(path) {
+      const payload = JSON.parse(document.getElementById('payload').value);
+      const response = await fetch(path, { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload) });
+      document.getElementById('output').textContent = JSON.stringify(await response.json(), null, 2);
+    }
+    async function queryDemo() {
+      const response = await fetch('/query', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({field: 'entity', operator: 'eq', value: 'invoice'}) });
+      document.getElementById('output').textContent = JSON.stringify(await response.json(), null, 2);
+    }
+  </script>
+</body>
+</html>
+""".strip()
 
 
 def _record_or_404(payload_id: str) -> IngestRecord:
@@ -53,6 +95,10 @@ if app is not None:
     def health() -> dict[str, str]:
         return {"status": "ok"}
 
+    @app.get("/demo", response_class=HTMLResponse)
+    def demo_page() -> str:
+        return DEMO_HTML
+
     @app.post("/validate")
     def validate_endpoint(payload: Any = Body(...)) -> dict[str, Any]:
         return validate_only(payload)
@@ -60,6 +106,13 @@ if app is not None:
     @app.post("/convert")
     def convert_endpoint(payload: Any = Body(...)) -> dict[str, Any]:
         result = convert_only(payload)
+        if result["status"] == "rejected":
+            raise HTTPException(status_code=400, detail=result)
+        return result
+
+    @app.post("/evaluate")
+    def evaluate_endpoint(payload: Any = Body(...)) -> dict[str, Any]:
+        result = evaluate_payload(payload, payload_name=str(payload.get("id", "payload")) if isinstance(payload, dict) else "payload")
         if result["status"] == "rejected":
             raise HTTPException(status_code=400, detail=result)
         return result
@@ -73,9 +126,40 @@ if app is not None:
             raise HTTPException(status_code=400, detail=result)
         return result
 
+    @app.post("/batch/ingest")
+    def batch_ingest_endpoint(payloads: list[Any] = Body(...)) -> dict[str, Any]:
+        records = build_batch_records(payloads, source="api-batch")
+        for record in records:
+            store.save(record)
+        accepted = [record for record in records if record.status == "validated"]
+        rejected = [record for record in records if record.status == "rejected"]
+        return {
+            "total": len(records),
+            "accepted": len(accepted),
+            "rejected": len(rejected),
+            "stored": len(records),
+            "records": [summarize_record(record) for record in records],
+        }
+
+    @app.post("/query")
+    def query_endpoint(query: dict[str, Any] = Body(...)) -> dict[str, Any]:
+        field = str(query.get("field", ""))
+        value = query.get("value")
+        operator = str(query.get("operator", "eq"))
+        if not field:
+            raise HTTPException(status_code=400, detail={"message": "field is required"})
+        try:
+            return hybrid_query_response(store.list(), field, value, operator)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail={"message": str(exc)}) from exc
+
     @app.get("/records")
     def list_records_endpoint() -> list[dict[str, Any]]:
         return [summarize_record(record) for record in store.list()]
+
+    @app.get("/records/search")
+    def search_records_endpoint(field: str, value: str) -> list[dict[str, Any]]:
+        return [summarize_record(record) for record in store.find_by_field(field, value)]
 
     @app.get("/records/{payload_id}")
     def read_record_endpoint(payload_id: str) -> dict[str, Any]:

--- a/src/toonflow/benchmark.py
+++ b/src/toonflow/benchmark.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from .converter import json_to_toon
+
+
+DEFAULT_COST_PER_MILLION_TOKENS_USD = 0.15
+
+
+@dataclass(slots=True)
+class BenchmarkResult:
+    payload_name: str
+    json_bytes: int
+    toon_bytes: int
+    byte_savings: int
+    byte_savings_percent: float
+    json_token_estimate: int
+    toon_token_estimate: int
+    token_savings: int
+    token_savings_percent: float
+    json_estimated_cost_usd: float
+    toon_estimated_cost_usd: float
+    estimated_cost_savings_usd: float
+    conversion_ms: float
+    records_per_second: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def estimate_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, round(len(text) / 4))
+
+
+def percentage_savings(original: int, compact: int) -> float:
+    if original <= 0:
+        return 0.0
+    return round(((original - compact) / original) * 100, 2)
+
+
+def estimate_cost_usd(tokens: int, cost_per_million_tokens: float = DEFAULT_COST_PER_MILLION_TOKENS_USD) -> float:
+    return round((tokens / 1_000_000) * cost_per_million_tokens, 8)
+
+
+def benchmark_payload(payload: dict[str, Any], payload_name: str = "payload") -> BenchmarkResult:
+    start = perf_counter()
+    toon_payload = json_to_toon(payload)
+    conversion_ms = max((perf_counter() - start) * 1000, 0.0001)
+
+    json_payload = canonical_json(payload)
+    json_bytes = len(json_payload.encode("utf-8"))
+    toon_bytes = len(toon_payload.encode("utf-8"))
+    json_tokens = estimate_tokens(json_payload)
+    toon_tokens = estimate_tokens(toon_payload)
+    json_cost = estimate_cost_usd(json_tokens)
+    toon_cost = estimate_cost_usd(toon_tokens)
+
+    return BenchmarkResult(
+        payload_name=payload_name,
+        json_bytes=json_bytes,
+        toon_bytes=toon_bytes,
+        byte_savings=json_bytes - toon_bytes,
+        byte_savings_percent=percentage_savings(json_bytes, toon_bytes),
+        json_token_estimate=json_tokens,
+        toon_token_estimate=toon_tokens,
+        token_savings=json_tokens - toon_tokens,
+        token_savings_percent=percentage_savings(json_tokens, toon_tokens),
+        json_estimated_cost_usd=json_cost,
+        toon_estimated_cost_usd=toon_cost,
+        estimated_cost_savings_usd=round(json_cost - toon_cost, 8),
+        conversion_ms=round(conversion_ms, 4),
+        records_per_second=round(1000 / conversion_ms, 2),
+    )
+
+
+def benchmark_payloads(payloads: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    results = [benchmark_payload(payload, name) for name, payload in payloads.items()]
+    totals = {
+        "json_bytes": sum(item.json_bytes for item in results),
+        "toon_bytes": sum(item.toon_bytes for item in results),
+        "json_token_estimate": sum(item.json_token_estimate for item in results),
+        "toon_token_estimate": sum(item.toon_token_estimate for item in results),
+        "json_estimated_cost_usd": round(sum(item.json_estimated_cost_usd for item in results), 8),
+        "toon_estimated_cost_usd": round(sum(item.toon_estimated_cost_usd for item in results), 8),
+        "conversion_ms": round(sum(item.conversion_ms for item in results), 4),
+    }
+    totals["byte_savings"] = totals["json_bytes"] - totals["toon_bytes"]
+    totals["byte_savings_percent"] = percentage_savings(totals["json_bytes"], totals["toon_bytes"])
+    totals["token_savings"] = totals["json_token_estimate"] - totals["toon_token_estimate"]
+    totals["token_savings_percent"] = percentage_savings(totals["json_token_estimate"], totals["toon_token_estimate"])
+    totals["estimated_cost_savings_usd"] = round(
+        totals["json_estimated_cost_usd"] - totals["toon_estimated_cost_usd"], 8
+    )
+    totals["records_per_second"] = round((len(results) * 1000) / totals["conversion_ms"], 2) if totals["conversion_ms"] else 0.0
+    return {"results": [item.to_dict() for item in results], "totals": totals}
+
+
+def load_json_payloads(directory: str | Path) -> dict[str, dict[str, Any]]:
+    payloads: dict[str, dict[str, Any]] = {}
+    for path in sorted(Path(directory).glob("*.json")):
+        payloads[path.stem] = json.loads(path.read_text(encoding="utf-8"))
+    return payloads
+
+
+def write_benchmark_report(report: dict[str, Any], output_path: str | Path) -> None:
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_markdown_report(report: dict[str, Any], output_path: str | Path) -> None:
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    totals = report["totals"]
+    lines = [
+        "# JSON vs TOON Benchmark Results",
+        "",
+        "| Payload | JSON bytes | TOON bytes | Byte savings | Token savings | Conversion ms |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for item in report["results"]:
+        lines.append(
+            f"| {item['payload_name']} | {item['json_bytes']} | {item['toon_bytes']} | "
+            f"{item['byte_savings_percent']}% | {item['token_savings_percent']}% | {item['conversion_ms']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Totals",
+            "",
+            f"- JSON bytes: {totals['json_bytes']}",
+            f"- TOON bytes: {totals['toon_bytes']}",
+            f"- Byte savings: {totals['byte_savings_percent']}%",
+            f"- Estimated token savings: {totals['token_savings_percent']}%",
+            f"- Estimated cost savings: ${totals['estimated_cost_savings_usd']}",
+            f"- Conversion throughput: {totals['records_per_second']} records/sec",
+            "",
+            "Token and cost values are estimates for repeatable local comparison.",
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/src/toonflow/evaluator.py
+++ b/src/toonflow/evaluator.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .benchmark import benchmark_payload
+from .converter import flatten_query_fields, json_to_toon
+from .validator import validate_payload
+
+
+def evaluate_payload(payload: dict[str, Any], payload_name: str = "payload") -> dict[str, Any]:
+    validation = validate_payload(payload)
+    if not validation.ok:
+        return {
+            "status": "rejected",
+            "validation": {"ok": False, "errors": validation.errors, "warnings": validation.warnings},
+            "toon_payload": "",
+            "extracted_fields": {},
+            "metrics": None,
+        }
+
+    return {
+        "status": "ready",
+        "validation": {"ok": True, "errors": validation.errors, "warnings": validation.warnings},
+        "toon_payload": json_to_toon(payload),
+        "extracted_fields": flatten_query_fields(payload),
+        "metrics": benchmark_payload(payload, payload_name).to_dict(),
+    }

--- a/src/toonflow/query.py
+++ b/src/toonflow/query.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from .models import IngestRecord
+
+
+SUPPORTED_OPERATORS = {"eq", "contains", "gt", "gte", "lt", "lte"}
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def field_matches(actual: Any, expected: Any, operator: str = "eq") -> bool:
+    if operator not in SUPPORTED_OPERATORS:
+        raise ValueError(f"Unsupported operator: {operator}")
+    if operator == "eq":
+        return str(actual) == str(expected)
+    if operator == "contains":
+        return str(expected).lower() in str(actual).lower()
+
+    actual_number = _as_float(actual)
+    expected_number = _as_float(expected)
+    if actual_number is None or expected_number is None:
+        return False
+    if operator == "gt":
+        return actual_number > expected_number
+    if operator == "gte":
+        return actual_number >= expected_number
+    if operator == "lt":
+        return actual_number < expected_number
+    return actual_number <= expected_number
+
+
+def query_records(records: Iterable[IngestRecord], field: str, value: Any, operator: str = "eq") -> list[IngestRecord]:
+    return [record for record in records if field in record.extracted_fields and field_matches(record.extracted_fields[field], value, operator)]
+
+
+def build_sql_preview(field: str, operator: str = "eq") -> dict[str, Any]:
+    if operator not in SUPPORTED_OPERATORS:
+        raise ValueError(f"Unsupported operator: {operator}")
+    json_path = '$."' + field.replace('"', '\\"') + '"'
+    comparator = {"eq": "=", "contains": "LIKE", "gt": ">", "gte": ">=", "lt": "<", "lte": "<="}[operator]
+    sql = f"""
+    SELECT payload_id, source, toon_payload, extracted_fields
+    FROM toon_records
+    WHERE JSON_UNQUOTE(JSON_EXTRACT(extracted_fields, %s)) {comparator} %s
+    ORDER BY created_at DESC
+    """.strip()
+    return {
+        "sql": sql,
+        "params": [json_path, "%value%" if operator == "contains" else "value"],
+        "note": "Preview only; the demo filters extracted fields, then returns TOON payloads for AI context.",
+    }
+
+
+def hybrid_query_response(records: Iterable[IngestRecord], field: str, value: Any, operator: str = "eq") -> dict[str, Any]:
+    matches = query_records(records, field, value, operator)
+    return {
+        "query": {"field": field, "operator": operator, "value": value},
+        "sql_preview": build_sql_preview(field, operator),
+        "matched_count": len(matches),
+        "records": [
+            {
+                "payload_id": record.payload_id,
+                "source": record.source,
+                "status": record.status,
+                "matched_value": record.extracted_fields.get(field),
+                "toon_payload": record.toon_payload,
+                "extracted_fields": record.extracted_fields,
+            }
+            for record in matches
+        ],
+    }

--- a/tasks/task-breakdown.md
+++ b/tasks/task-breakdown.md
@@ -50,12 +50,14 @@ All tasks are currently assigned to: **Dominic Low**
 - Basic batch error reporting
 - Start: 25 Apr 2026
 - Target completion: 26 Apr 2026
+- Status: implemented in PR #15. Batch ingest API stores accepted and rejected records, reports total/accepted/rejected/stored counts, and keeps rejected batch items auditable.
 
 ### 7. Benchmark protocol and measurements
 - Define benchmark inputs and method
 - Measure payload size, token count, estimated cost, conversion time, ingestion throughput
 - Start: 25 Apr 2026
 - Target completion: 27 Apr 2026
+- Status: implemented in PR #15. Benchmark tooling measures JSON vs TOON bytes, estimated tokens/cost, conversion time, and throughput, and writes JSON plus Markdown reports.
 
 ### 8. Interactive demo
 - Paste JSON
@@ -66,6 +68,7 @@ All tasks are currently assigned to: **Dominic Low**
 - Export record
 - Start: 27 Apr 2026
 - Target completion: 28 Apr 2026
+- Status: implemented in PR #15. Interactive `/demo` page plus evaluator/query endpoints support paste-JSON evaluation, validation, conversion, metrics, storage, hybrid query, and export flow.
 
 ### 9. Testing, polish, and final demo readiness
 - Reliability pass
@@ -74,3 +77,4 @@ All tasks are currently assigned to: **Dominic Low**
 - Final repo cleanup
 - Start: 28 Apr 2026
 - Target completion: 28 Apr 2026
+- Status: implemented in PR #15. Full verification script runs tests, core pipeline, and benchmark generation; docs and readiness instructions updated.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,12 @@ def test_health_endpoint():
     assert response.json() == {"status": "ok"}
 
 
+def test_demo_page_loads():
+    response = client.get("/demo")
+    assert response.status_code == 200
+    assert "TOONFlow evaluator" in response.text
+
+
 def test_validate_endpoint_accepts_valid_payload():
     response = client.post("/validate", json=valid_payload("api-validate-001"))
     assert response.status_code == 200
@@ -60,6 +66,13 @@ def test_convert_endpoint_returns_400_for_invalid_payload():
     response = client.post("/convert", json={"entity": "invoice"})
     assert response.status_code == 400
     assert response.json()["detail"]["status"] == "rejected"
+
+
+def test_evaluate_endpoint_returns_metrics_and_toon():
+    response = client.post("/evaluate", json=valid_payload("api-eval-001"))
+    assert response.status_code == 200
+    assert response.json()["metrics"]["json_bytes"] > 0
+    assert response.json()["toon_payload"]
 
 
 def test_ingest_read_and_export_record_flow():
@@ -116,6 +129,38 @@ def test_list_records_endpoint_includes_ingested_records():
     response = client.get("/records")
     assert response.status_code == 200
     assert [item["payload_id"] for item in response.json()] == ["api-list-001"]
+
+
+def test_batch_ingest_endpoint_stores_mixed_statuses():
+    response = client.post(
+        "/batch/ingest",
+        json=[valid_payload("api-batch-ok"), {"id": "api-batch-bad", "entity": "invoice"}],
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert body["accepted"] == 1
+    assert body["rejected"] == 1
+    assert body["stored"] == 2
+
+    rejected = client.get("/records/api-batch-bad")
+    assert rejected.status_code == 200
+    assert rejected.json()["status"] == "rejected"
+
+
+def test_search_records_endpoint_filters_extracted_fields():
+    assert client.post("/ingest", json=valid_payload("api-search-001")).status_code == 200
+    response = client.get("/records/search", params={"field": "entity", "value": "invoice"})
+    assert response.status_code == 200
+    assert [item["payload_id"] for item in response.json()] == ["api-search-001"]
+
+
+def test_query_endpoint_returns_hybrid_results():
+    assert client.post("/ingest", json=valid_payload("api-query-001")).status_code == 200
+    response = client.post("/query", json={"field": "entity", "operator": "eq", "value": "invoice"})
+    assert response.status_code == 200
+    assert response.json()["matched_count"] == 1
+    assert "JSON_EXTRACT" in response.json()["sql_preview"]["sql"]
 
 
 def test_api_flow_with_valid_and_invalid_fixture_payloads():

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from toonflow.benchmark import (
+    benchmark_payload,
+    benchmark_payloads,
+    canonical_json,
+    estimate_cost_usd,
+    estimate_tokens,
+    load_json_payloads,
+    percentage_savings,
+    write_benchmark_report,
+    write_markdown_report,
+)
+
+
+def payload():
+    return {
+        "id": "bench-001",
+        "entity": "invoice",
+        "timestamp": "2026-04-24T10:00:00Z",
+        "data": {"customer": {"name": "Alice"}, "amount": 245.5},
+    }
+
+
+def test_canonical_json_is_compact_and_stable():
+    assert canonical_json({"b": 2, "a": 1}) == '{"a":1,"b":2}'
+
+
+def test_estimate_tokens_costs_and_savings_are_repeatable():
+    assert estimate_tokens("abcd") == 1
+    assert estimate_cost_usd(1_000_000, 0.15) == 0.15
+    assert percentage_savings(100, 75) == 25.0
+
+
+def test_benchmark_payload_returns_expected_metric_shape():
+    result = benchmark_payload(payload(), "invoice")
+    assert result.payload_name == "invoice"
+    assert result.json_bytes > 0
+    assert result.toon_bytes > 0
+    assert result.json_token_estimate > 0
+    assert result.records_per_second > 0
+
+
+def test_benchmark_payloads_returns_totals():
+    report = benchmark_payloads({"invoice": payload()})
+    assert len(report["results"]) == 1
+    assert "estimated_cost_savings_usd" in report["totals"]
+    assert "records_per_second" in report["totals"]
+
+
+def test_load_and_write_benchmark_reports(tmp_path: Path):
+    sample_path = tmp_path / "sample.json"
+    sample_path.write_text(canonical_json(payload()), encoding="utf-8")
+    loaded = load_json_payloads(tmp_path)
+    assert loaded["sample"]["entity"] == "invoice"
+
+    report = benchmark_payloads(loaded)
+    json_output = tmp_path / "report.json"
+    md_output = tmp_path / "report.md"
+    write_benchmark_report(report, json_output)
+    write_markdown_report(report, md_output)
+    assert "json_bytes" in json_output.read_text(encoding="utf-8")
+    assert "JSON vs TOON Benchmark Results" in md_output.read_text(encoding="utf-8")

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,26 @@
+from toonflow.evaluator import evaluate_payload
+
+
+def valid_payload():
+    return {
+        "id": "eval-001",
+        "entity": "invoice",
+        "timestamp": "2026-04-24T10:00:00Z",
+        "data": {"customer": {"name": "Alice"}, "amount": 245.5},
+    }
+
+
+def test_evaluate_payload_returns_demo_ready_response():
+    result = evaluate_payload(valid_payload(), "invoice")
+    assert result["status"] == "ready"
+    assert result["validation"]["ok"] is True
+    assert result["toon_payload"]
+    assert result["extracted_fields"]["data.customer.name"] == "Alice"
+    assert result["metrics"]["payload_name"] == "invoice"
+
+
+def test_evaluate_payload_rejects_invalid_contract():
+    result = evaluate_payload({"entity": "invoice"})
+    assert result["status"] == "rejected"
+    assert result["metrics"] is None
+    assert result["validation"]["errors"]

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,46 @@
+import pytest
+
+from toonflow.models import IngestRecord
+from toonflow.query import build_sql_preview, field_matches, hybrid_query_response, query_records
+
+
+def record(payload_id="r1", amount=245.5):
+    return IngestRecord(
+        payload_id=payload_id,
+        source="test",
+        original_json={},
+        toon_payload="entity: invoice",
+        extracted_fields={"entity": "invoice", "data.amount": amount},
+        status="validated",
+    )
+
+
+def test_field_matches_supported_operators():
+    assert field_matches("invoice", "invoice") is True
+    assert field_matches("priority billing", "billing", "contains") is True
+    assert field_matches(10, 5, "gt") is True
+    assert field_matches(10, 10, "gte") is True
+    assert field_matches(5, 10, "lt") is True
+    assert field_matches(5, 5, "lte") is True
+
+
+def test_query_records_filters_extracted_fields():
+    matches = query_records([record("a", 100), record("b", 300)], "data.amount", 200, "gt")
+    assert [item.payload_id for item in matches] == ["b"]
+
+
+def test_build_sql_preview_describes_mariadb_json_field_lookup():
+    preview = build_sql_preview("data.amount", "gte")
+    assert "JSON_EXTRACT(extracted_fields" in preview["sql"]
+    assert preview["params"][0] == '$."data.amount"'
+
+
+def test_hybrid_query_response_returns_toon_payloads():
+    response = hybrid_query_response([record()], "entity", "invoice")
+    assert response["matched_count"] == 1
+    assert response["records"][0]["toon_payload"] == "entity: invoice"
+
+
+def test_invalid_operator_raises():
+    with pytest.raises(ValueError):
+        field_matches("a", "a", "bad")


### PR DESCRIPTION
## Summary
- add batch ingest endpoint with mixed accepted/rejected record reporting
- add JSON vs TOON benchmark protocol, JSON results, Markdown report, and runner script
- add evaluator response flow with validation, TOON conversion, extracted fields, and metrics
- add hybrid extracted-field query flow returning TOON payloads
- add `/demo` interactive evaluator page
- add final verification script covering tests, core pipeline, and benchmark generation
- update roadmap, architecture, task breakdown, and local development docs

## Validation
- PYTHONPATH=src python scripts/verify_all.py
- 72 passed, 1 skipped
- core pipeline run: 2 accepted, 2 rejected, 4 stored
- benchmark run: JSON bytes 543, TOON bytes 492, byte savings 9.39%, estimated token savings 9.56%

## Scope
Built on top of #14. This completes the remaining planned delivery steps: batch ingestion, benchmark protocol/results, interactive evaluator demo, and final polish/readiness.

Closes #7
Closes #8
Closes #9
Closes #10
